### PR TITLE
Better color in example for custom fluids

### DIFF
--- a/docs/Mods/ContentTweaker/Vanilla/Creatable_Content/Fluid.md
+++ b/docs/Mods/ContentTweaker/Vanilla/Creatable_Content/Fluid.md
@@ -63,8 +63,9 @@ fluid.register();
 #loader contenttweaker
 import mods.contenttweaker.VanillaFactory;
 import mods.contenttweaker.Fluid;
+import mods.contenttweaker.Color;
 
-var zsFluid = VanillaFactory.createFluid("zs_fluid", 0);
+var zsFluid = VanillaFactory.createFluid("zs_fluid", Color.fromHex("FF69B4"));
 zsFluid.fillSound = <soundevent:block.anvil.place>;
 zsFluid.register();
 ```


### PR DESCRIPTION
passing a color 0 works but makes an invisible fluid, probably not the best example. Replaced with Color.fromHex() since that's likely to be to most commonly used function there.