### PR TITLE
Fix syntax for removing entity drops

### DIFF
--- a/docs/Vanilla/Entities/IEntityDefinition.md
+++ b/docs/Vanilla/Entities/IEntityDefinition.md
@@ -85,8 +85,8 @@ This removes a drop.
 ```
 val entity = <entity:minecraft:sheep>;
 
-//remove(item);
-entity.remove(<minecraft:wool>);
+//removeDrop(item);
+entity.removeDrop(<minecraft:wool>);
 ```
 `item` is the item to be removed from being a drop and an [IItemStack](/Vanilla/Items/IItemStack).
 

--- a/docs/Vanilla/Entities/IEntityDefinition.md
+++ b/docs/Vanilla/Entities/IEntityDefinition.md
@@ -90,6 +90,15 @@ entity.removeDrop(<minecraft:wool>);
 ```
 `item` is the item to be removed from being a drop and an [IItemStack](/Vanilla/Items/IItemStack).
 
+### Clear Drops
+
+This removes all drops.
+```
+val entity = <entity:minecraft:sheep>;
+
+//clearDrops
+entity.clearDrops;
+```
 
 ### Get
 


### PR DESCRIPTION
The example here is incorrect. It says you need to use remove but in reality you need to use removeDrop to remove a drop.