### PR TITLE
Update Enchanter.md (TE Arcane Ensorcellator documentation)

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Enchanter.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Enchanter.md
@@ -8,7 +8,7 @@
 ```
 mods.thermalexpansion.Enchanter.addRecipe(IItemStack output, IItemStack input, IItemStack secondInput, int energy, int experience, boolean empowered);
 
-mods.thermalexpansion.Enchanter.addRecipe(<minecraft:diamond>, <minecraft:dirt>, <minecraft:plank>, 2048, 20, true);
+mods.thermalexpansion.Enchanter.addRecipe(<minecraft:enchanted_book>.withTag({StoredEnchantments: [{id: 35}]}), <minecraft:book>, <minecraft:diamond>, 12000, 3000, false);
 ```
 
 ## Removal
@@ -16,5 +16,5 @@ mods.thermalexpansion.Enchanter.addRecipe(<minecraft:diamond>, <minecraft:dirt>,
 ```
 mods.thermalexpansion.Enchanter.removeRecipe(IItemStack input, IItemStack secondInput);
 
-mods.thermalexpansion.Enchanter.removeRecipe(<minecraft:dirt>, <minecraft:plank>);
+mods.thermalexpansion.Enchanter.removeRecipe(<minecraft:book>, <minecraft:diamond>);
 ```


### PR DESCRIPTION
Suggesting a more realistic example recipe to demonstrate how players might add new enchantments to the Arcane Ensorcellator, because I was struggling to figure out how to get it to work by using the previous example. (In particular, using boolean false for the 'empowered' argument, as 'true' isn't even implemented currently & won't function if set.)

This particular example simply adds an alternate recipe for the Fortune I enchantment, using exactly the same costs as the default Thermal Expansion recipe, but using a diamond rather than an emerald.