### PR TITLE
Add AE2 CT support documentation

### DIFF
--- a/docs/Mods/Applied_Energistics_2/Applied_Energistics_2.md
+++ b/docs/Mods/Applied_Energistics_2/Applied_Energistics_2.md
@@ -1,0 +1,10 @@
+# Applied Energistics 2
+
+## Information
+Applied Energistics 2 is a Minecraft Mod which contains a large amount of new content, mostly centered around item storage and the ME Network. The mod adds Craft Tweaker integration for some custom machines recipes and config options. 
+
+### For More Information
+https://ae-mod.info/
+
+### Bug Reports
+https://github.com/AppliedEnergistics/Applied-Energistics-2/issues

--- a/docs/Mods/Applied_Energistics_2/Cannon.md
+++ b/docs/Mods/Applied_Energistics_2/Cannon.md
@@ -1,0 +1,15 @@
+#Cannon
+
+### Importing
+
+```
+import mods.appliedenergistics2.Cannon;
+```
+
+### Adding
+Adds ammo types for the matter cannon. Weight refers to (roughly) the atomic weight of the material. 
+```
+Cannon.registerAmmo(ItemStack itemStack, double weight);
+
+Cannon.registerAmmo(<minecraft:bone>, 40.07);
+```

--- a/docs/Mods/Applied_Energistics_2/Cannon.md
+++ b/docs/Mods/Applied_Energistics_2/Cannon.md
@@ -9,7 +9,7 @@ import mods.appliedenergistics2.Cannon;
 ### Adding
 Adds ammo types for the matter cannon. Weight refers to (roughly) the atomic weight of the material. 
 ```
-Cannon.registerAmmo(ItemStack itemStack, double weight);
+Cannon.registerAmmo(IItemStack ammo, double weight);
 
 Cannon.registerAmmo(<minecraft:bone>, 40.07);
 ```

--- a/docs/Mods/Applied_Energistics_2/Grindstone.md
+++ b/docs/Mods/Applied_Energistics_2/Grindstone.md
@@ -9,7 +9,7 @@ import mods.appliedenergistics2.Grinder;
 ### Adding
 
 ```
-Grinder.addRecipe(ItemStack output, ItemStack input, int turns, @Optional ItemStack secondary1Output, @Optional float secondary1Chance, @Optional ItemStack secondary2Output, @Optional float secondary2Chance);
+Grinder.addRecipe(IItemStack output, IItemStack input, int turns, @Optional IItemStack secondary1Output, @Optional float secondary1Chance, @Optional IItemStack secondary2Output, @Optional float secondary2Chance);
 
 Grinder.addRecipe(<minecraft:sapling>, <minecraft:leaves>, 4, <minecraft:sapling:5>, 0.3);
 ```
@@ -17,7 +17,7 @@ Grinder.addRecipe(<minecraft:sapling>, <minecraft:leaves>, 4, <minecraft:sapling
 ### Removing
 
 ```
-Grinder.removeRecipe(ItemStack input);
+Grinder.removeRecipe(IItemStack input);
 
 Grinder.removeRecipe(<minecraft:quartz_ore>);
 ```

--- a/docs/Mods/Applied_Energistics_2/Grindstone.md
+++ b/docs/Mods/Applied_Energistics_2/Grindstone.md
@@ -1,0 +1,23 @@
+#Grindstone
+
+### Importing
+
+```
+import mods.appliedenergistics2.Grinder;
+```
+
+### Adding
+
+```
+Grinder.addRecipe(ItemStack output, ItemStack input, int turns, @Optional ItemStack secondary1Output, @Optional float secondary1Chance, @Optional ItemStack secondary2Output, @Optional float secondary2Chance);
+
+Grinder.addRecipe(<minecraft:sapling>, <minecraft:leaves>, 4, <minecraft:sapling:5>, 0.3);
+```
+
+### Removing
+
+```
+Grinder.removeRecipe(ItemStack input);
+
+Grinder.removeRecipe(<minecraft:quartz_ore>);
+```

--- a/docs/Mods/Applied_Energistics_2/Inscriber.md
+++ b/docs/Mods/Applied_Energistics_2/Inscriber.md
@@ -1,0 +1,28 @@
+#Inscriber
+
+### Importing
+
+```
+import mods.appliedenergistics2.Inscriber;
+```
+
+### Adding
+When the `inscribe` boolean is true, the top and bottom inputs are not consumed. 
+```
+Inscriber.addRecipe(ItemStack output, ItemStack input, boolean inscribe, @Optional ItemStack topInput, @Optional ItemStack bottomInput);
+
+//turns eggs into Wither Skele spawn eggs, does not consume wither skull
+Inscriber.addRecipe(<minecraft:spawn_egg:5>, <minecraft:egg>, true, <minecraft:skull:1>);
+
+//combines bread, coco beans, and sugar. all inputs are consumed
+Inscriber.addRecipe(<minecraft:cookie>, <minecraft:minecraft:bread>, false, <minecraft:dye:3>, <minecraft:sugar>);
+```
+
+### Removing
+
+```
+Inscriber.removeRecipe(ItemStack output);
+
+//removes printed silicon recipe 
+Inscriber.removeRecipe(<appliedenergistics2:material:20>); 
+```

--- a/docs/Mods/Applied_Energistics_2/Inscriber.md
+++ b/docs/Mods/Applied_Energistics_2/Inscriber.md
@@ -9,7 +9,7 @@ import mods.appliedenergistics2.Inscriber;
 ### Adding
 When the `inscribe` boolean is true, the top and bottom inputs are not consumed. 
 ```
-Inscriber.addRecipe(ItemStack output, ItemStack input, boolean inscribe, @Optional ItemStack topInput, @Optional ItemStack bottomInput);
+Inscriber.addRecipe(IItemStack output, IItemStack input, boolean inscribe, @Optional IItemStack topInput, @Optional IItemStack bottomInput);
 
 //turns eggs into Wither Skele spawn eggs, does not consume wither skull
 Inscriber.addRecipe(<minecraft:spawn_egg:5>, <minecraft:egg>, true, <minecraft:skull:1>);
@@ -21,7 +21,7 @@ Inscriber.addRecipe(<minecraft:cookie>, <minecraft:minecraft:bread>, false, <min
 ### Removing
 
 ```
-Inscriber.removeRecipe(ItemStack output);
+Inscriber.removeRecipe(IItemStack output);
 
 //removes printed silicon recipe 
 Inscriber.removeRecipe(<appliedenergistics2:material:20>); 

--- a/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
+++ b/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
@@ -1,0 +1,56 @@
+#P2P Attunement
+
+### Importing
+
+```
+import mods.appliedenergistics2.Attunement;
+```
+
+### Attuning ItemStack
+Attune a ItemStack or ModID to a specific P2P-Tunnel type. ModID's are used as fallback when no ItemStack was found.
+
+### ME P2P
+```
+Attunement.attuneME(ItemStack itemStack);
+Attunement.attuneME(String modID);
+
+Attunement.attuneME(<appliedenergistics2:controller>);
+Attunement.attuneME("actuallyadditions");
+```
+
+### Item P2P
+```
+Attunement.attuneItem(ItemStack itemStack);
+Attunement.attuneItem(String modID);
+```
+
+### Fluid P2P
+```
+Attunement.attuneFluid(ItemStack itemStack);
+Attunement.attuneFluid(String modID);
+```
+
+### Redstone P2P
+```
+Attunement.attuneRedstone(ItemStack itemStack);
+Attunement.attuneRedstone(String modID);
+```
+
+### RF P2P
+```
+Attunement.attuneRF(ItemStack itemStack);
+Attunement.attuneRF(String modID);
+```
+
+### EU P2P
+```
+Attunement.attuneIC2(ItemStack itemStack);
+Attunement.attuneIC2(String modID);
+```
+
+### Light P2P
+```
+Attunement.attuneLight(ItemStack itemStack);
+Attunement.attuneLight(String modID);
+```
+

--- a/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
+++ b/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
@@ -6,12 +6,12 @@
 import mods.appliedenergistics2.Attunement;
 ```
 
-### Attuning ItemStack
-Attune a ItemStack or ModID to a specific P2P-Tunnel type. ModID's are used as fallback when no ItemStack was found.
+### Attuning Item
+Attune an IItemStack or ModID to a specific P2P-Tunnel type. ModID's are used as fallback when no IItemStack was found.
 
 ### ME P2P
 ```
-Attunement.attuneME(ItemStack itemStack);
+Attunement.attuneME(IItemStack IItemStack);
 Attunement.attuneME(String modID);
 
 Attunement.attuneME(<appliedenergistics2:controller>);
@@ -20,37 +20,37 @@ Attunement.attuneME("actuallyadditions");
 
 ### Item P2P
 ```
-Attunement.attuneItem(ItemStack itemStack);
+Attunement.attuneItem(IItemStack IItemStack);
 Attunement.attuneItem(String modID);
 ```
 
 ### Fluid P2P
 ```
-Attunement.attuneFluid(ItemStack itemStack);
+Attunement.attuneFluid(IItemStack IItemStack);
 Attunement.attuneFluid(String modID);
 ```
 
 ### Redstone P2P
 ```
-Attunement.attuneRedstone(ItemStack itemStack);
+Attunement.attuneRedstone(IItemStack IItemStack);
 Attunement.attuneRedstone(String modID);
 ```
 
 ### RF P2P
 ```
-Attunement.attuneRF(ItemStack itemStack);
+Attunement.attuneRF(IItemStack IItemStack);
 Attunement.attuneRF(String modID);
 ```
 
 ### EU P2P
 ```
-Attunement.attuneIC2(ItemStack itemStack);
+Attunement.attuneIC2(IItemStack IItemStack);
 Attunement.attuneIC2(String modID);
 ```
 
 ### Light P2P
 ```
-Attunement.attuneLight(ItemStack itemStack);
+Attunement.attuneLight(IItemStack IItemStack);
 Attunement.attuneLight(String modID);
 ```
 

--- a/docs/Mods/Applied_Energistics_2/Spatial.md
+++ b/docs/Mods/Applied_Energistics_2/Spatial.md
@@ -1,0 +1,18 @@
+#Spatial
+
+### Importing
+
+```
+import mods.appliedenergistics2.Spatial;
+```
+
+### Adding
+Whitelist a TileEntity class for Spatial IO.
+```
+Spatial.whitelistEntity(String fullEntityClassName);
+
+//Adds the AA small storage crate to the spatial IO whitelist
+Spatial.whitelistEntity("de.ellpeck.actuallyadditions.mod.tile.TileEntityGiantChest");
+```
+
+

--- a/docs/Mods/Applied_Energistics_2/Spatial.md
+++ b/docs/Mods/Applied_Energistics_2/Spatial.md
@@ -8,6 +8,7 @@ import mods.appliedenergistics2.Spatial;
 
 ### Adding
 Whitelist a TileEntity class for Spatial IO.
+Warning: Some title entities, especially multiblock structures, may cause unexpected errors or crash when moved into Spatial IO. Pack devs should throughly test any additions to the Spatial IO whitelist. 
 ```
 Spatial.whitelistEntity(String fullEntityClassName);
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,13 @@ pages:
     - Advanced Mortars:
       - Advanced Mortars: 'Mods/Advanced_Mortars/Advanced_Mortars.md'
       - CraftTweaker Support: 'Mods/Advanced_Mortars/CraftTweaker_Support/Mortars.md'
+    - Applied Energistics 2:
+      - Applied Energistics 2: 'Mods/Applied_Energistics_2/Applied_Energistics_2.md'
+      - Cannon: 'Mods/Applied_Energistics_2/Cannon.md'
+      - Grindstone: 'Mods/Applied_Energistics_2/Grindstone.md'
+      - Inscriber: 'Mods/Applied_Energistics_2/Inscriber.md'
+      - P2P Attunement: 'Mods/Applied_Energistics_2/P2P_Attunement.md'
+      - Spatial I/O: 'Mods/Applied_Energistics_2/Spatial.md'
     - Artisan Worktables:
       - RecipeBuilder: 
         - RecipeBuilder: 'Mods/Artisan_Worktables/CraftTweaker_Support/RecipeBuilder.md'


### PR DESCRIPTION
Tested all the examples do work. Only added one set of examples to the P2P_Attunement pages. While there's 7 categories, they all take either an itemstack or string so one example should get the point across (plus I'd be surprised if anyone actually used that function). 