### PR TITLE
Correcting Command/Commands Typo

### DIFF
--- a/docs/Vanilla/Commands/ICommand.md
+++ b/docs/Vanilla/Commands/ICommand.md
@@ -4,7 +4,7 @@ An ICommand Object represents a command ingame.
 
 ## Importing the package
 It might be required for you to import the package if you encounter any issues (like casting an [Array](/AdvancedFunctions/Arrays_and_Loops/)), so better be safe than sorry and add the import.  
-`import crafttweaker.commands.ICommand;`
+`import crafttweaker.command.ICommand;`
 
 ## ZenGetters
 

--- a/docs/Vanilla/Commands/ICommandManager.md
+++ b/docs/Vanilla/Commands/ICommandManager.md
@@ -5,7 +5,7 @@ You can get this from an [IServer](/Vanilla/Game/IServer/) object.
 
 ## Importing the package
 It might be required for you to import the package if you encounter any issues (like casting an [Array](/AdvancedFunctions/Arrays_and_Loops/)), so better be safe than sorry and add the import.  
-`import crafttweaker.commands.ICommandManager;`
+`import crafttweaker.command.ICommandManager;`
 
 ## ZenGetters
 

--- a/docs/Vanilla/Commands/ICommandSender.md
+++ b/docs/Vanilla/Commands/ICommandSender.md
@@ -5,7 +5,7 @@ Each [IEntity](/Vanilla/Entities/IEntity/) and [IPlayer](/Vanilla/Players/IPlaye
 
 ## Importing the package
 It might be required for you to import the package if you encounter any issues (like casting an [Array](/AdvancedFunctions/Arrays_and_Loops/)), so better be safe than sorry and add the import.  
-`import crafttweaker.commands.ICommandSender;`
+`import crafttweaker.command.ICommandSender;`
 
 ## ZenGetter
 


### PR DESCRIPTION
Correcting inaccurate pluralization in ICommand documentation.