### PR TITLE
Update Centrifuge mob documentation.

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Centrifugal_Seperator.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Centrifugal_Seperator.md
@@ -11,9 +11,33 @@ mods.thermalexpansion.Centrifuge.addRecipe([(<minecraft:gold_ingot> * 5) % 10, <
 
 ```
 
+## Mob addition
+
+`fluid` can be null, in which case the default Thermal Expansion experience liquid will be used, the amount calculated from the `xp` field using the default `XP_TO_MB` constant from Thermal Expansion. When using a custom liquid, the `xp` field is ignored.
+
+**No custom fluid**:
+
+```
+//mods.thermalexpansion.Centrifuge.addRecipeMob(IEntityDefinition entity, WeightedItemStack[] outputs, @Nullable ILiquidStack fluid, int energy, int xp);
+mods.thermalexpansion.Centrifuge.addRecipeMob(<entity:minecraft:slime>, [<minecraft:clay_ball>%50, <minecraft:ghast_tear>%10], null, 2000, 5);
+```
+
+**Custom fluid**:
+
+```
+mods.thermalexpansion.Centrifuge.addRecipeMob(<entity:minecraft:slime>, [<minecraft:gunpowder>%100], <liquid:lava>*20, 2000, 0);
+```
+
 ## Removal
 
 ```
 //mods.thermalexpansion.Centrifuge.removeRecipe(IItemStack input);
 mods.thermalexpansion.Centrifuge.removeRecipe(<minecraft:gold_ore>);
+```
+
+## Mob removal
+
+```
+//mods.thermalexpansion.Centrifuge.removeRecipeMob(IEntityDefinition entity);
+mods.thermalexpansion.Centrifuge.removeRecipeMob(<entity:minecraft:slime>);
 ```


### PR DESCRIPTION
Mob removal and addition can also be done using Strings, but the preferred method would be to use `<entity:MODID:MODNAME>` instead.