### PR TITLE
Update Alchemy Array to match actual function

### DIFF
--- a/docs/Mods/Modtweaker/BloodMagic/AlchemyArray.md
+++ b/docs/Mods/Modtweaker/BloodMagic/AlchemyArray.md
@@ -6,9 +6,9 @@
 ## Addition
 
 ```
-//mods.bloodmagic.AlchemyArray.addRecipe(IItemStack input, IItemStack catalyst, IItemStack output, @Optional string textureLocation);
-mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:stick>, <minecraft:grass>, <minecraft:diamond>, "bloodmagic:textures/models/AlchemyArrays/LightSigil.png");
-mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:stick>, <minecraft:grass>, <minecraft:diamond>);
+//mods.bloodmagic.AlchemyArray.addRecipe(IItemStack output, IItemStack catalyst, IItemStack input, @Optional string textureLocation);
+mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:grass>, <minecraft:stick>, "bloodmagic:textures/models/AlchemyArrays/LightSigil.png");
+mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:grass>, <minecraft:stick>);
 ```
 
 ## Removal


### PR DESCRIPTION
As noted by Saereth and Emalios on Discord, the correct function for the Alchemy Array is: 

` public static void addRecipe(IItemStack output, IItemStack input, IItemStack catalyst, @Optional String textureLocation)`

Meaning, the output comes first rather than the input. This commit fixes the confusion in the documentation.