### PR TITLE
Update "Remove Brewing Recipes" page to say it works with JEI version 4.15.0.275 or higher

### DIFF
--- a/docs/Vanilla/Recipes/Recipes_Brewing_Stand.md
+++ b/docs/Vanilla/Recipes/Recipes_Brewing_Stand.md
@@ -27,7 +27,7 @@ brewing.addBrew(<minecraft:gold_block>, [<minecraft:iron_block>, <minecraft:lapi
 
 ### Remove Brewing Recipes
 
-Still doesn't work with JEI!!
+Only works with JEI version 4.15.0.275 or higher.
 
 ```
 //brewing.removeRecipe(IItemStack input, IItemStack ingredient);


### PR DESCRIPTION
The bug was reported and fixed here: https://github.com/mezz/JustEnoughItems/issues/1518