### PR TITLE
Alchemy Array: Actually fix it.

### DIFF
--- a/docs/Mods/Modtweaker/BloodMagic/AlchemyArray.md
+++ b/docs/Mods/Modtweaker/BloodMagic/AlchemyArray.md
@@ -6,9 +6,10 @@
 ## Addition
 
 ```
-//mods.bloodmagic.AlchemyArray.addRecipe(IItemStack output, IItemStack catalyst, IItemStack input, @Optional string textureLocation);
-mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:grass>, <minecraft:stick>, "bloodmagic:textures/models/AlchemyArrays/LightSigil.png");
-mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:grass>, <minecraft:stick>);
+//mods.bloodmagic.AlchemyArray.addRecipe(IItemStack output, IItemStack input, IItemStack catalyst, @Optional string textureLocation);
+mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:stick>, <minecraft:grass>, "bloodmagic:textures/models/AlchemyArrays/LightSigil.png");
+mods.bloodmagic.AlchemyArray.addRecipe(<minecraft:diamond>, <minecraft:stick>, <minecraft:grass>);
+// creates an alchemy array recipe with the output of diamond. the first item placed into the array is the stick (the input), followed by the grass (the catalyst)
 ```
 
 ## Removal


### PR DESCRIPTION
I didn't realise how severely the order was messed up. This is accurate according to the function description: 
`public static void addRecipe(IItemStack output, IItemStack input, IItemStack catalyst, @Optional String textureLocation) {`

Which is translate into the add, ` public Add(ItemStack input, ItemStack catalyst, ItemStack output, ResourceLocation location) {`

Which is translated into the API call, `BloodMagicAPI.INSTANCE.getRecipeRegistrar().addAlchemyArray(input, catalyst, output, location);`

Which has the signature of: ```java
    /**
     * Adds a new recipe to the Alchemy Array.
     *
     * @param input         An input {@link Ingredient}. First item put into the Alchemy Array.
     * @param catalyst      A catalyst {@link Ingredient}. Second item put into the Alchemy Array.
     * @param output        An output {@link ItemStack}.
     * @param circleTexture The texture to render for the Alchemy Array circle.
     */
    void addAlchemyArray(@Nonnull Ingredient input, @Nonnull Ingredient catalyst, @Nonnull ItemStack output, @Nullable ResourceLocation circleTexture);```

I've also clarified that the input is the first item to be inserted, and the catalyst is the second item.