### PR TITLE
PlayerPickupItem actually returns IEntityItem.

### DIFF
--- a/docs/Vanilla/Events/Events/PlayerPickupItem.md
+++ b/docs/Vanilla/Events/Events/PlayerPickupItem.md
@@ -18,5 +18,5 @@ The following information can be retrieved from the event:
 
 | ZenGetter   | Return Type                            |
 |-------------|----------------------------------------|
-| `item`      | [IItemStack](/Vanilla/Items/IItemStack/)| 
+| `item`      | [IEntityItem](/Vanilla/Entities/IEntityItem/)| 
 | `player`    | [IPlayer](/Vanilla/Players/IPlayer/)    |


### PR DESCRIPTION
Not IItemStack as previously stated; this may have previously been the case, but is no longer.