### PR TITLE
onToolHeal should be calcToolHeal

### DIFF
--- a/docs/Mods/ContentTweaker/Tinkers_Construct/TraitBuilder.md
+++ b/docs/Mods/ContentTweaker/Tinkers_Construct/TraitBuilder.md
@@ -379,7 +379,7 @@ myTrait.onToolDamage = function(trait, tool, unmodifiedAmount, newAmount, holder
 ```
 
 
-### onToolHeal
+### calcToolHeal
 Called before the tools durability is getting increased.  
 Parameters:
 
@@ -393,7 +393,7 @@ __Returns an int__ representing the new amount. Otherwise return `newAmount`
 
 Created using
 ```
-myTrait.onToolHeal = function(trait, tool, unmodifiedAmount, newAmount, holder) {
+myTrait.calcToolHeal = function(trait, tool, unmodifiedAmount, newAmount, holder) {
 	//CODE
 	return newAmount; //Or your modified value
 };


### PR DESCRIPTION
According to the ContentTweaker code, you need to use calcToolHeal instead of onToolHeal. In my script, I needed calcToolHeal to get the script to work properly.