### PR TITLE
Fixed EntityLivingDeathDrops drops documentation

### DIFF
--- a/docs/Vanilla/Events/Events/EntityLivingDeathDrops.md
+++ b/docs/Vanilla/Events/Events/EntityLivingDeathDrops.md
@@ -22,7 +22,7 @@ The following information can be retrieved from the event:
 | ZenGetter       | Return Type                                          |
 |-----------------|------------------------------------------------------|
 | `player`        | [IPlayer](/Vanilla/Players/IPlayer/)                  |
-| `items`         | [`List<IEntityItem>`](/Vanilla/Entities/IEntityItem/) |
+| `drops`         | [`List<IEntityItem>`](/Vanilla/Entities/IEntityItem/) |
 | `damageSource`  | [IDamageSource](/Vanilla/Damage/IDamageSource/)       |
 | `isRecentlyHit` | bool                                                 |
 | `lootingLevel`  | int                                                  |
@@ -31,7 +31,7 @@ The following information can be retrieved from the event:
 
 You can either add to the droplist or completely substitute it with a new one:
 ```zenscript
-event.items = //reference to IEntityItem list.
+event.drops = //reference to IEntityItem list.
 
 //event.addItem(IItemStack item);
 event.addItem(<minecraft:iron_ingot>);


### PR DESCRIPTION
EntityLivingDeathDrops referred to a zen attribute called items but it is actually called drops (see [corresponding crafttweaker api source](https://github.com/CraftTweaker/CraftTweaker/blob/ffb96eba30f7bc2b765414de72c53881d2117a53/CraftTweaker2-API/src/main/java/crafttweaker/api/event/EntityLivingDeathDropsEvent.java))