### PR TITLE
fix: typos

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Factorizer.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Factorizer.md
@@ -28,7 +28,7 @@ mods.thermalexpansion.Factorizer.addRecipeBoth(<minecraft:trapped_chest>, <minec
 ## Remove Recipes
 
 You can of course also remove recipes.  
-If you want to remove a two-way binding you'll need tow calls, though.
+If you want to remove a two-way binding you'll need two calls, though.
 
 ```zenscript
 //mods.thermalexpansion.Factorizer.removeRecipeSplit(IItemStack in);

--- a/docs/Mods/Modtweaker/ThermalExpansion/Factorizer.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Factorizer.md
@@ -1,18 +1,18 @@
 # Factorizer
 
-The Factorizer Manager allows you to add recipes to the factorizer.  
-
+The Factorizer Manager allows you to add recipes to the factorizer.
 
 ## Import the package
-To shorten method calls you can [import](/AdvancedFunctions/Import/) the package like so:  
+
+To shorten method calls you can [import](/AdvancedFunctions/Import/) the package like so:
+
 ```zenscript
 import mods.thermalexpansion.Factorizer;
 ```
 
 ## Add Recipes
 
-You can add oneway split/combine recipes or two-way bindings.  
-
+You can add oneway split/combine recipes or two-way bindings.
 
 ```zenscript
 //mods.thermalexpansion.Factorizer.addRecipeSplit(IItemStack in, IItemStack out);
@@ -25,11 +25,11 @@ mods.thermalexpansion.Factorizer.addRecipeCombine(<minecraft:grass> * 5, <minecr
 mods.thermalexpansion.Factorizer.addRecipeBoth(<minecraft:trapped_chest>, <minecraft:chest> * 13);
 ```
 
-
 ## Remove Recipes
 
 You can of course also remove recipes.  
 If you want to remove a two-way binding you'll need tow calls, though.
+
 ```zenscript
 //mods.thermalexpansion.Factorizer.removeRecipeSplit(IItemStack in);
 mods.thermalexpansion.Factorizer.removeRecipeSplit(<minecraft:iron_block>);

--- a/docs/Mods/Modtweaker/ThermalExpansion/InductionSmelter.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/InductionSmelter.md
@@ -15,7 +15,7 @@ mods.thermalexpansion.InductionSmelter.addRecipe(<minecraft:diamond>, <minecraft
 ## Removal
 
 ```zenscript
-mods.thermalexpansion.InductionSmelter.removeRecipe(input);
+mods.thermalexpansion.InductionSmelter.removeRecipe(IItemStack primaryInput, IItemStack secondaryInput);
 
 mods.thermalexpansion.InductionSmelter.removeRecipe(<minecraft:bucket>, <minecraft:sand>);
 ```

--- a/docs/Mods/Modtweaker/ThermalExpansion/InductionSmelter.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/InductionSmelter.md
@@ -1,6 +1,7 @@
 # InductionSmelter
 
 ## Package
+
 `mods.thermalexpansion.InductionSmelter`
 
 ## Addition

--- a/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
@@ -20,7 +20,7 @@ mods.thermalexpansion.RedstoneFurnace.removeRecipe(<minecraft:gold_ore>);
 
 ## Pyrolitic Augment Addition
 
-**_Note that the energy is multiplied by `1.5`. If you specify `2000` energy, the recipe will actually cost `3000` RF. Likewise if you specify `1500`, it will case `2250` RF._**
+**_Note that the energy is multiplied by `1.5`. If you specify `2000` energy, the recipe will actually cost `3000` RF. Likewise if you specify `1500`, it will cost `2250` RF._**
 
 Example recipe to turn charcoal into coal coke, producing 250mb of creosote oil in the process.
 

--- a/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
@@ -1,6 +1,7 @@
 #Redstone Furnace
 
 ## Package
+
 `mods.thermalexpansion.RedstoneFurnace`
 
 ## Addition
@@ -19,7 +20,7 @@ mods.thermalexpansion.RedstoneFurnace.removeRecipe(<minecraft:gold_ore>);
 
 ## Pyrolitic Augment Addition
 
-***Note that the energy is multiplied by `1.5`. If you specify `2000` energy, the recipe will actually cost `3000` RF. Likewise if you specify `1500`, it will case `2250` RF.***
+**_Note that the energy is multiplied by `1.5`. If you specify `2000` energy, the recipe will actually cost `3000` RF. Likewise if you specify `1500`, it will case `2250` RF._**
 
 Example recipe to turn charcoal into coal coke, producing 250mb of creosote oil in the process.
 


### PR DESCRIPTION
- Fixed a few typos I found while going through the docs
- Removed whitespaces (automatic by editor)
- Fixed Induction Smelter's removeRecipe function missing its second parameter