### PR TITLE
Fix typo in section headers for Forestry Centrifuge and Charcoal Pile

### DIFF
--- a/translations/de/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/de/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/de/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/de/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/fr/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/fr/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/fr/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/fr/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/ja/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/ja/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/ja/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/ja/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/ko/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/ko/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/ko/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/ko/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/pl/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/pl/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/pl/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/pl/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/ru/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/ru/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/ru/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/ru/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 

--- a/translations/zh/docs/Mods/Modtweaker/Forestry/Centrifuge.md
+++ b/translations/zh/docs/Mods/Modtweaker/Forestry/Centrifuge.md
@@ -14,7 +14,7 @@ mods.forestry.Centrifuge.removeRecipe(<forestry:bee_combs:*>);
 
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 ```zenscript
 //mods.forestry.Centrifuge.addRecipe(WeightedItemStack[] output, IItemStack ingredients, int packagingTime);

--- a/translations/zh/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
+++ b/translations/zh/docs/Mods/Modtweaker/Forestry/Charcoal_Pile.md
@@ -22,7 +22,7 @@ mods.forestry.CharcoalWall.removeWallState(<blockstate:minecraft:bedrock>);
 mods.forestry.CharcoalWall.removeWallStack(<minecraft:bedrock>);
 ```
 
-## Reipe Addition
+## Recipe Addition
 
 `amount` states the amount of charcoal the wall will provide.
 


### PR DESCRIPTION
There were typos on the Forestry mod section. The headers said "Reipe Addition" instead of "Recipe Addition".