### PR TITLE
Correct drops syntax in IEntityDefinition

### DIFF
--- a/docs/Vanilla/Entities/IEntityDefinition.md
+++ b/docs/Vanilla/Entities/IEntityDefinition.md
@@ -118,6 +118,6 @@ This returns all drops that were added via CT as list of [IEntityDrop](/Vanilla/
 ```zenscript
 val entity = <entity:minecraft:sheep>;
 
-//getDrops();
-val dropList = entity.getDrops();
+//drops;
+val dropList = entity.drops;
 ```


### PR DESCRIPTION
from `getDrops()`
to `drops`