### PR TITLE
Correct IEntity to remove blockPos and getBlockPos

### DIFF
--- a/docs/Vanilla/Entities/IEntity.md
+++ b/docs/Vanilla/Entities/IEntity.md
@@ -16,8 +16,7 @@ IEntity extends [ICommandSender](/Vanilla/Commands/ICommandSender/). That means 
 		<li>entity.position</li>
 		<li>entity.world</li>
 		<li>entity.server</li>
-    <li>stack.server</li>
-    <li>sender.sendMessage(String text)</li>
+    		<li>entity.sendMessage(String text)</li>
 	</ul>
 </details>
 

--- a/docs/Vanilla/Entities/IEntity.md
+++ b/docs/Vanilla/Entities/IEntity.md
@@ -13,9 +13,9 @@ IEntity extends [ICommandSender](/Vanilla/Commands/ICommandSender/). That means 
 <details><summary>Derived Methods</summary>
 	<ul>
 		<li>entity.displayName</li>
-		<li>stack.position</li>
-		<li>stack.world</li>
-		<li>stack.server</li>
+		<li>entity.position</li>
+		<li>entity.world</li>
+		<li>entity.server</li>
     <li>stack.server</li>
     <li>sender.sendMessage(String text)</li>
 	</ul>

--- a/docs/Vanilla/Entities/IEntity.md
+++ b/docs/Vanilla/Entities/IEntity.md
@@ -10,6 +10,17 @@ It might be required for you to import the package if you encounter any issues (
 ## Extending ICommandSender
 IEntity extends [ICommandSender](/Vanilla/Commands/ICommandSender/). That means that all methods that are availabel to [ICommandSender](/Vanilla/Commands/ICommandSender/) Objects also are available to IEntity Objects!
 
+<details><summary>Derived Methods</summary>
+	<ul>
+		<li>entity.displayName</li>
+		<li>stack.position</li>
+		<li>stack.world</li>
+		<li>stack.server</li>
+    <li>stack.server</li>
+    <li>sender.sendMessage(String text)</li>
+	</ul>
+</details>
+
 
 ## ZenGetters
 
@@ -19,7 +30,6 @@ IEntity extends [ICommandSender](/Vanilla/Commands/ICommandSender/). That means 
 | alive                       | isAlive()           | boolean                                      |
 | alwaysRenderNameTag         |                     | boolean                                      |
 | armorInventory              |                     | List<[IItemStack](/Vanilla/Items/IItemStack/) |
-| blockPos                    | getBlockPos()       | [IBlockPos](/Vanilla/World/IBlockPos/)        |
 | canBeAttackedWithItem       |                     | boolean                                      |
 | canBeCollidedWith           |                     | boolean                                      |
 | canPassengerSteer           |                     | boolean                                      |


### PR DESCRIPTION
Removed `blockPos` and `getBlockPos()`, added **Derived Methods** from `ICommandSender`. 
Format for **Derived Methods** taken directly from `IItemDefinition` and methods taken directly from `ICommandSender`.