### PR TITLE
Fix IDamageSource import statement typo

### DIFF
--- a/docs/Vanilla/Damage/IDamageSource.md
+++ b/docs/Vanilla/Damage/IDamageSource.md
@@ -4,7 +4,7 @@ An IDamageSource object is the source of damage to an entity.
 
 ## Importing the class
 It might be required to [import](/AdvancedFunctions/Import/) the class to avoid errors.  
-`import crafttweaker.damage.IDamage`
+`import crafttweaker.damage.IDamageSource`
 
 
 ## Zengetters and ZenMethods without parameters


### PR DESCRIPTION
It was `import crafttweaker.damage.IDamage` whcih results in the error `No such member: IDamage`.
This corrects it to `import crafttweaker.damage.IDamageSource`.