### PR TITLE
Remove player from EntityLivingDeathDrops

### DIFF
--- a/docs/Vanilla/Events/Events/EntityLivingDeathDrops.md
+++ b/docs/Vanilla/Events/Events/EntityLivingDeathDrops.md
@@ -21,7 +21,6 @@ The following information can be retrieved from the event:
 
 | ZenGetter       | Return Type                                          |
 |-----------------|------------------------------------------------------|
-| `player`        | [IPlayer](/Vanilla/Players/IPlayer/)                  |
 | `drops`         | [`List<IEntityItem>`](/Vanilla/Entities/IEntityItem/) |
 | `damageSource`  | [IDamageSource](/Vanilla/Damage/IDamageSource/)       |
 | `isRecentlyHit` | bool                                                 |


### PR DESCRIPTION
There's no `player` member in `EntityLivingDeathDrops`, this information should be obtainted through the `IDamageSource` member. 
script: https://pastebin.com/BhLews12
log: https://pastebin.com/Vgfa2WaT (see line 341)