### PR TITLE
Expand upon Thermal Expansion Compactor documentation to include more details

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Compactor.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Compactor.md
@@ -3,15 +3,18 @@
 ## Package
 `mods.thermalexpansion.Compactor`
 
-The compactor supports 3 types of mods:
+The compactor supports 4 types of modifiers:
 
 ```
 Mint
 Press
 Storage
+Gear
 ```
 
 ## Mint
+The Mint modifier changes the recipes registered in the `COIN` recipe map in Thermal Expansion.
+Note that these recipes require the Numismatic Press Augment.
 
 ### Addition
 
@@ -30,6 +33,8 @@ mods.thermalexpansion.Compactor.removeMintRecipe(<thermalfoundation:material:167
 ```
 
 ## Press
+The Press modifier changes the recipes not registered in the `PLATE`, `COIN`, or `GEAR` recipe maps in Thermal Expansion.
+These recipes do not require a specific Augment.
 
 ### Addition
 
@@ -48,6 +53,8 @@ mods.thermalexpansion.Compactor.removePressRecipe(<thermalfoundation:material:16
 ```
 
 ## Storage
+The Storage modifier changes the recipes registered in the `PLATE` recipe map in Thermal Expansion.
+These recipes do not require a specific Augment, and seemingly are used only for plates.
 
 ### Addition
 
@@ -66,6 +73,8 @@ mods.thermalexpansion.Compactor.removeStorageRecipe(<thermalfoundation:material:
 ```
 
 ## Gear
+The Gear modifier changes the recipes registered in the `GEAR` recipe map in Thermal Expansion.
+Note that these recipes require the Gearworking Die Augment.
 
 ### Addition
 ```zenscript

--- a/docs/Mods/Modtweaker/ThermalExpansion/Compactor.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Compactor.md
@@ -14,6 +14,7 @@ Gear
 
 ## Mint
 The Mint modifier changes the recipes registered in the `COIN` recipe map in Thermal Expansion.
+
 Note that these recipes require the Numismatic Press Augment.
 
 ### Addition
@@ -34,6 +35,7 @@ mods.thermalexpansion.Compactor.removeMintRecipe(<thermalfoundation:material:167
 
 ## Press
 The Press modifier changes the recipes not registered in the `PLATE`, `COIN`, or `GEAR` recipe maps in Thermal Expansion.
+
 These recipes do not require a specific Augment.
 
 ### Addition
@@ -54,6 +56,7 @@ mods.thermalexpansion.Compactor.removePressRecipe(<thermalfoundation:material:16
 
 ## Storage
 The Storage modifier changes the recipes registered in the `PLATE` recipe map in Thermal Expansion.
+
 These recipes do not require a specific Augment, and seemingly are used only for plates.
 
 ### Addition
@@ -74,6 +77,7 @@ mods.thermalexpansion.Compactor.removeStorageRecipe(<thermalfoundation:material:
 
 ## Gear
 The Gear modifier changes the recipes registered in the `GEAR` recipe map in Thermal Expansion.
+
 Note that these recipes require the Gearworking Die Augment.
 
 ### Addition


### PR DESCRIPTION
After doing some reading of source code, I was able to figure out some information on how the Compactor's Modtweaker compact interfaces with Thermal Expansion's API which wasn't clearly expressed in the Docs.

Added in this Pull Request:

- Updated the statement on the number of modifiers from 3 to 4, and added the missing modifier to the list
- Added specifications on what recipe map each modifier alters to avoid confusion
- Listed the usage of each modifier, either by describing what recipes it acts on, or by listing the Augment said recipes use. 