### PR TITLE
fix(docs/mod): exnihilocreatio typo-ed as exnihilocreation

### DIFF
--- a/docs/Mods/Ex_Nihilo_Creatio/Crooking.md
+++ b/docs/Mods/Ex_Nihilo_Creatio/Crooking.md
@@ -14,13 +14,13 @@ mods.exnihilocreatio.Crook
 ## Addition
 
 ```zenscript
-mods.exnihilocreation.Crook.addRecipe(IIngredient, IItemStack, Float, Float);
+mods.exnihilocreatio.Crook.addRecipe(IIngredient, IItemStack, Float, Float);
 
-mods.exnihilocreation.Crook.addRecipe(<minecraft:log>, <minecraft:plank>, 0.25, 0.5);
+mods.exnihilocreatio.Crook.addRecipe(<minecraft:log>, <minecraft:plank>, 0.25, 0.5);
 ```
 
 ## Removal 
 
 ```zenscript
-mods.exnihilocreation.Crook.removeAll();
+mods.exnihilocreatio.Crook.removeAll();
 ```

--- a/docs/Mods/Ex_Nihilo_Creatio/Heating_Sources.md
+++ b/docs/Mods/Ex_Nihilo_Creatio/Heating_Sources.md
@@ -13,13 +13,13 @@
 ## Addition
 
 ```zenscript
-mods.exnihilocreation.Heat.addRecipe(IItemStack, Int);
+mods.exnihilocreatio.Heat.addRecipe(IItemStack, Int);
 
-mods.exnihilocreation.Heat.addRecipe(<minecraft:log>, 20);
+mods.exnihilocreatio.Heat.addRecipe(<minecraft:log>, 20);
 ```
 
 ## Removal 
 
 ```zenscript
-mods.exnihilocreation.Heat.removeAll();
+mods.exnihilocreatio.Heat.removeAll();
 ```

--- a/docs/Mods/Ex_Nihilo_Creatio/Sieving.md
+++ b/docs/Mods/Ex_Nihilo_Creatio/Sieving.md
@@ -41,5 +41,5 @@ addDiamondMeshRecipe(<minecraft:gravel>, <minecraft:diamond>, 1);
 ## Removal 
 
 ```zenscript
-mods.exnihilocreation.Sieve.removeAll();
+mods.exnihilocreatio.Sieve.removeAll();
 ```


### PR DESCRIPTION
Fixes CraftTweaker/CraftTweaker-Documentation#289