### PR TITLE
fix(nav): sort mods navigation alphabetically

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,10 +145,10 @@ nav:
             - ItemBuilderBasic: 'mods/contenttweaker/API/item/basic/ItemBuilderBasic.md'
           - Tool:
             - ItemBuilderTool: 'mods/contenttweaker/API/item/tool/ItemBuilderTool.md'
-    - JEITweaker:
-        - JEITweaker: 'mods/JEITweaker/JEITweaker.md'
     - InitialInventory:
         - InitialInventory: 'mods/InitialInventory/InitialInventory.md'
+    - JEITweaker:
+        - JEITweaker: 'mods/JEITweaker/JEITweaker.md'
     - StoneAge:
         - Drying Rack: 'mods/StoneAge/DryingRackManager.md'
         - Flint Workbench: 'mods/StoneAge/FlintWorkbenchManager.md'


### PR DESCRIPTION
As subcategories of the navigation have generally been sorted alphabetically, I've adjusted the mods to follow that standard.

I had left alone the vanilla category (How To being above API) as I took it as an intentional decision to bring focus to that category before the rest.