### PR TITLE
feat(mods): Add BuildCraft docs

### DIFF
--- a/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
+++ b/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
@@ -1,0 +1,78 @@
+# Assembly Table
+
+*Requires BuildCraft Silicon*
+
+Class path: `mods.buildcraft.AssemblyTable`
+
+## Use
+
+To use, import the class with `import mods.buildcraft.AssemblyTable;` as the beginning of your script.
+
+## Adding a Recipe
+
+`AssemblyTable.addRecipe(recipeName, output, power, inputs);`
+
+- `recipeName` (Optional) &lt;string> The name of the recipe. *Must be unique!*
+- `output` <[IItemStack](/vanilla/api/items/IItemStack)>
+- `power` &lt;int> Total power cost in MJ
+- `inputs` <[IIngredient](/vanilla/api/items/IIngredient)[]>
+
+```zenscript
+import mods.buildcraft.AssemblyTable;
+
+AssemblyTable.addRecipe("example_recipe_for_diamonds", <minecraft:diamond>, 1000, [<minecraft:coal_block>, <minecraft:redstone>]);
+```
+
+## Removing a Recipe
+
+`AssemblyTable.removeByName(name);`
+
+- `recipeName` &lt;string> The name of the recipe.
+
+```zenscript
+import mods.buildcraft.AssemblyTable;
+
+AssemblyTable.removeByName("buildcraftsilicon:redstone_chipset");
+```
+
+## Existing Recipes
+
+### Chipsets:
+
+- `buildcraftsilicon:redstone_chipset`
+- `buildcraftsilicon:iron_chipset`
+- `buildcraftsilicon:gold_chipset`
+- `buildcraftsilicon:quartz_chipset`
+- `buildcraftsilicon:diamond_chipset`
+
+### Pluggables:
+
+- `buildcraftsilicon:plug_pulsar` 
+- `buildcraftsilicon:light-sensor`
+- `buildcrafttransport:facaderecipes`
+
+### Lenses:
+
+- `buildcraftsilicon:lens-regular`
+- `buildcraftsilicon:lens-filter`
+- `buildcraftsilicon:lens-regular-<color>`
+- `buildcraftsilicon:lens-filter-<color>`
+
+*Replace `<color>` with any of the following: `white`, `orange`, `magenta`, `lightblue`, `yellow`, `lime`, `pink`, `gray`, `silver`, `cyan`, `purple`, `blue`, `brown`, `green`, `red`, `black`*
+
+### Wires:
+
+- `buildcrafttransport:wire-<color>`
+
+*Replace `<color>` with any of the following: `white`, `orange`, `magenta`, `lightblue`, `yellow`, `lime`, `pink`, `gray`, `silver`, `cyan`, `purple`, `blue`, `brown`, `green`, `red`, `black`*
+
+### Gates:
+
+- `buildcraftsilicon:gate-<operation>-<material>-no_modifier`
+- `buildcraftsilicon:gate-modifier-<operation>-<material>-<modifier>`
+
+**Parameters:**
+
+- `<operation>`: `and` or `or`
+- `<material>`: `iron`, `nether_brick`, or `gold`
+- `<modifier>`: `lapis`, `quartz` or `diamond`

--- a/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
+++ b/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
@@ -6,7 +6,7 @@ Class path: `mods.buildcraft.AssemblyTable`
 
 ## Use
 
-To use, import the class with `import mods.buildcraft.AssemblyTable;` as the beginning of your script.
+To use, import the class with `import mods.buildcraft.AssemblyTable;` at the beginning of your script.
 
 ## Adding a Recipe
 
@@ -71,8 +71,8 @@ AssemblyTable.removeByName("buildcraftsilicon:redstone_chipset");
 - `buildcraftsilicon:gate-<operation>-<material>-no_modifier`
 - `buildcraftsilicon:gate-modifier-<operation>-<material>-<modifier>`
 
-**Parameters:**
+Parameters:
 
 - `<operation>`: `and` or `or`
 - `<material>`: `iron`, `nether_brick`, or `gold`
-- `<modifier>`: `lapis`, `quartz` or `diamond`
+- `<modifier>`: `lapis`, `quartz`, or `diamond`

--- a/docs/Mods/BuildCraft/Energy/CombustionEngine.md
+++ b/docs/Mods/BuildCraft/Energy/CombustionEngine.md
@@ -6,7 +6,7 @@ Class path: `mods.buildcraft.CombustionEngine`
 
 ## Use
 
-To use, import the class with `import mods.buildcraft.CombustionEngine;` as the beginning of your script.
+To use, import the class with `import mods.buildcraft.CombustionEngine;` at the beginning of your script.
 
 ## Adding a Clean Fuel
 

--- a/docs/Mods/BuildCraft/Energy/CombustionEngine.md
+++ b/docs/Mods/BuildCraft/Energy/CombustionEngine.md
@@ -1,0 +1,38 @@
+# Combustion Engine
+
+*Requires BuildCraft Energy*
+
+Class path: `mods.buildcraft.CombustionEngine`
+
+## Use
+
+To use, import the class with `import mods.buildcraft.CombustionEngine;` as the beginning of your script.
+
+## Adding a Clean Fuel
+
+`CombustionEngine.addCleanFuel(liquid, powerPerTick, timePerBucket);`
+
+- `liquid` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The liquid to be used as fuel
+- `powerPerTick` &lt;double> Power output in MJ per tick
+- `timePerBucket` &lt;int> Amount of ticks that 1,000 mB (1 bucket) should run for
+
+```zenscript
+import mods.buildcraft.CombustionEngine;
+
+CombustionEngine.addCleanFuel(<liquid:iron>, 32.0, 1200);
+```
+
+## Adding a Dirty Fuel
+
+`CombustionEngine.addDirtyFuel(lFuel, powerPerTick, timePerBucket, lResidue);`
+
+- `lFuel` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The liquid to be used as fuel
+- `powerPerTick` &lt;double> Power output in MJ per tick
+- `timePerBucket` &lt;int> Amount of ticks that 1,000 mB (1 bucket) should run for
+- `lResidue` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The residue fluid, per bucket of the original fuel
+
+```zenscript
+import mods.buildcraft.CombustionEngine;
+
+CombustionEngine.addDirtyFuel(<liquid:iron>, 32.0, 1200, <liquid:water>);
+```

--- a/docs/Mods/BuildCraft/index.md
+++ b/docs/Mods/BuildCraft/index.md
@@ -1,0 +1,3 @@
+# BuildCraft
+
+To use crafttwaeker with BuildCraft, make sure to install the full [BuildCraft Package](https://www.curseforge.com/minecraft/mc-mods/buildcraft) or the [BuildCraft Compat Module](https://www.curseforge.com/minecraft/mc-mods/buildcraft-compat)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -270,6 +270,10 @@ nav:
         - Starlight Infusion: 'Mods/Astral_Sorcery/Infusion.md'
         - Starlight Transmutation: 'Mods/Astral_Sorcery/Transmutation.md'
         - Util: 'Mods/Astral_Sorcery/Util.md'
+    - BuildCraft:
+        - Home: 'Mods/BuildCraft/index.md'
+        - Crafting:
+            - 'Mods/BuildCraft/Crafting/AssemblyTable.md'
     - Calculator:
       - Algorithm Seperator: 'Mods/Calculator/Algorithm_Seperator.md'
       - Atomic Calculator: 'Mods/Calculator/Atomic_Calculator.md'


### PR DESCRIPTION
This adds BuildCraft's CraftTweaker support to the documentation. Unlike documentation I was able to find, this includes proper examples, and each parameter is fully explained.