### PR TITLE
fix(docs): broken headers & styling tweaks

### DIFF
--- a/docs/Mods/Applied_Energistics_2/Cannon.md
+++ b/docs/Mods/Applied_Energistics_2/Cannon.md
@@ -1,4 +1,4 @@
-#Cannon
+# Cannon
 
 ### Importing
 

--- a/docs/Mods/Applied_Energistics_2/Grindstone.md
+++ b/docs/Mods/Applied_Energistics_2/Grindstone.md
@@ -1,4 +1,4 @@
-#Grindstone
+# Grindstone
 
 ### Importing
 

--- a/docs/Mods/Applied_Energistics_2/Inscriber.md
+++ b/docs/Mods/Applied_Energistics_2/Inscriber.md
@@ -1,4 +1,4 @@
-#Inscriber
+# Inscriber
 
 ### Importing
 

--- a/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
+++ b/docs/Mods/Applied_Energistics_2/P2P_Attunement.md
@@ -1,4 +1,4 @@
-#P2P Attunement
+# P2P Attunement
 
 ### Importing
 

--- a/docs/Mods/Applied_Energistics_2/Spatial.md
+++ b/docs/Mods/Applied_Energistics_2/Spatial.md
@@ -1,4 +1,4 @@
-#Spatial
+# Spatial
 
 ### Importing
 

--- a/docs/Mods/ContentTweaker/Materials/MaterialSystem.md
+++ b/docs/Mods/ContentTweaker/Materials/MaterialSystem.md
@@ -65,7 +65,7 @@ Required Parameters:
 - String name: The Part's name
 
 ## [IPartDataPiece](/Mods/ContentTweaker/Materials/Parts/PartDataPiece/)
-###Create
+### Create
 ```
 createPartDataPiece(String name, boolean required)
 ```

--- a/docs/Mods/ContentTweaker/Tinkers_Construct/TraitDataRepresentation.md
+++ b/docs/Mods/ContentTweaker/Tinkers_Construct/TraitDataRepresentation.md
@@ -21,7 +21,7 @@ It might be required for you to import the class if you encounter any issues (li
 | colorString | ✔         |              | string  |
 
 
-##ZenMethods
+## ZenMethods
 
 ```zenscript
 //Does the same as myTraitData.info;

--- a/docs/Mods/ContentTweaker/Vanilla/Types/Item/IMutableItemStack.md
+++ b/docs/Mods/ContentTweaker/Vanilla/Types/Item/IMutableItemStack.md
@@ -7,7 +7,7 @@ That means all of [IItemStack](/Vanilla/Items/IItemStack/)'s methods, and those 
 It might be required for you to import the package if you encounter any issues, so better be safe than sorry and add the import.  
 `import mods.contenttweaker.MutableItemStack;` 
 
-##ZenMethods
+## ZenMethods
 
 ### Quantity
 A Stack's count is the number of items in that stack!

--- a/docs/Mods/ContentTweaker/Vanilla/Types/Sound/ISoundTypeDefinition.md
+++ b/docs/Mods/ContentTweaker/Vanilla/Types/Sound/ISoundTypeDefinition.md
@@ -10,7 +10,7 @@ It might be required for you to import the package if you encounter any issues, 
 You can get such an object using the [Sound Type Bracket Handler](/Mods/ContentTweaker/Vanilla/Brackets/Bracket_Sound_Type/):  
 `<soundtype:wood>`
 
-##ZenMethods without parameters
+## ZenMethods without parameters
 |ZenMethod       |Return type                                    |Definition                                                         |
 |----------------|-----------------------------------------------|-------------------------------------------------------------------|
 |getVolume()     |float                                          |Returns the type's volume                                          |

--- a/docs/Mods/Immersive_Engineering/CraftTweaker_Support/Excavator/Mineral_Mix.md
+++ b/docs/Mods/Immersive_Engineering/CraftTweaker_Support/Excavator/Mineral_Mix.md
@@ -44,7 +44,7 @@ You will need to use the oredict names.
 mineralMixObject.removeOre("oreIron");
 ```
 
-##Fail Chance Getter/Setter
+## Fail Chance Getter/Setter
 
 ### Example
 ```zenscript

--- a/docs/Mods/Industrial_Foregoing/BioReactor.md
+++ b/docs/Mods/Industrial_Foregoing/BioReactor.md
@@ -1,4 +1,4 @@
-#Bioreactor
+# Bioreactor
 
 ### Importing
 

--- a/docs/Mods/Industrial_Foregoing/ProteinReactor.md
+++ b/docs/Mods/Industrial_Foregoing/ProteinReactor.md
@@ -1,4 +1,4 @@
-#Protein Reactor
+# Protein Reactor
 
 ### Importing
 

--- a/docs/Mods/Modtweaker/Botania/Commands.md
+++ b/docs/Mods/Modtweaker/Botania/Commands.md
@@ -6,7 +6,7 @@ To access these commands you do the same as you do for CraftTweaker commands, yo
 
 # List of Botania Mod Tweaker Commands
 
-##Recipes
+## Recipes
 ### botbrews
 
 Usage:

--- a/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Redstone_Furnace.md
@@ -1,4 +1,4 @@
-#Redstone Furnace
+# Redstone Furnace
 
 ## Package
 

--- a/docs/Mods/ProjectE/EntityRandomizer.md
+++ b/docs/Mods/ProjectE/EntityRandomizer.md
@@ -10,7 +10,7 @@ Note: This [IEntityDefinition](/Vanilla/Entities/IEntityDefinition/) must be for
 ```zenscript
 mods.projecte.EntityRandomizer.addPeaceful(IEntityDefinition entityDefinition);
 
-#Allows turning peaceful creatures into zombies. 
+// Allows turning peaceful creatures into zombies. 
 mods.projecte.EntityRandomizer.addPeaceful(<entity:minecraft:zombie>);
 ```
 
@@ -18,7 +18,7 @@ mods.projecte.EntityRandomizer.addPeaceful(<entity:minecraft:zombie>);
 ```zenscript
 mods.projecte.EntityRandomizer.addMob(IEntityDefinition entityDefinition);
 
-#Allows turning hostile mobs into pigs.
+// Allows turning hostile mobs into pigs.
 mods.projecte.EntityRandomizer.addMob(<entity:minecraft:pig>);
 ```
 
@@ -29,7 +29,7 @@ mods.projecte.EntityRandomizer.addMob(<entity:minecraft:pig>);
 ```zenscript
 mods.projecte.EntityRandomizer.removePeaceful(IEntityDefinition entityDefinition);
 
-#Stops peaceful mobs being able to be turned into pigs.
+// Stops peaceful mobs being able to be turned into pigs.
 mods.projecte.EntityRandomizer.removePeaceful(<entity:minecraft:pig>);
 ```
 
@@ -37,18 +37,18 @@ mods.projecte.EntityRandomizer.removePeaceful(<entity:minecraft:pig>);
 ```zenscript
 mods.projecte.EntityRandomizer.removeMob(IEntityDefinition entityDefinition);
 
-#Stops hostile mobs being able to be turned into zombies.
+// Stops hostile mobs being able to be turned into zombies.
 mods.projecte.EntityRandomizer.removeMob(<entity:minecraft:zombie>);
 ```
 
 ### clearPeacefuls
 ```zenscript
-#Removes all randomized peaceful mob entries including ones registered by CraftTweaker before this call.
+// Removes all randomized peaceful mob entries including ones registered by CraftTweaker before this call.
 mods.projecte.EntityRandomizer.clearPeacefuls();
 ```
 
 ### clearMobs
 ```zenscript
-#Removes all randomized hostile mob entries including ones registered by CraftTweaker before this call.
+// Removes all randomized hostile mob entries including ones registered by CraftTweaker before this call.
 mods.projecte.EntityRandomizer.clearMobs();
 ```

--- a/docs/Mods/ProjectE/WorldTransmutation.md
+++ b/docs/Mods/ProjectE/WorldTransmutation.md
@@ -6,10 +6,10 @@ Adds a Philosopher Stone world transmutation, with an optional sneak click trans
 
 ### [IItemStack](/Vanilla/Items/IItemStack/)
 ```zenscript
-#If the IItemStack's do not have a coresponding block, air is used instead.
+// If the IItemStack's do not have a coresponding block, air is used instead.
 mods.projecte.WorldTransmutation.add(IItemStack output, IItemStack input, @Optional IItemStack sneakOutput);
 
-#Turn gold blocks into diamond blocks by right clicking, or into iron blocks by sneak right clicking 
+// Turn gold blocks into diamond blocks by right clicking, or into iron blocks by sneak right clicking 
 mods.projecte.WorldTransmutation.add(<minecraft:diamond_block>, <minecraft:gold_block>, <minecraft:iron_block>);
 ```
 
@@ -18,7 +18,7 @@ mods.projecte.WorldTransmutation.add(<minecraft:diamond_block>, <minecraft:gold_
 ```zenscript
 mods.projecte.WorldTransmutation.add(IBlockState output, IBlockState input, @Optional IBlockState sneakOutput);
 
-#Turn gold blocks into diamond blocks by right clicking, or into iron blocks by sneak right clicking
+// Turn gold blocks into diamond blocks by right clicking, or into iron blocks by sneak right clicking
 mods.projecte.WorldTransmutation.add(<blockstate:minecraft:diamond_block>, <blockstate:minecraft:gold_block>, <blockstate:minecraft:iron_block>);
 ```
 
@@ -29,10 +29,10 @@ Removes the Philosopher Stone world transmutations that have the same input, out
 
 ### [IItemStack](/Vanilla/Items/IItemStack/)
 ```zenscript
-#If the IItemStack's do not have a coresponding block, air is used instead.
+// If the IItemStack's do not have a coresponding block, air is used instead.
 mods.projecte.WorldTransmutation.remove(IItemStack output, IItemStack input, @Optional IItemStack sneakOutput);
 
-#Removes the recipe allowing cobblestone to be changed into stone/grass
+// Removes the recipe allowing cobblestone to be changed into stone/grass
 mods.projecte.WorldTransmutation.remove(<minecraft:stone>, <minecraft:cobblestone>, <minecraft:grass>);
 ```
 
@@ -41,7 +41,7 @@ mods.projecte.WorldTransmutation.remove(<minecraft:stone>, <minecraft:cobbleston
 ```zenscript
 mods.projecte.WorldTransmutation.remove(IBlockState output, IBlockState input, @Optional IBlockState sneakOutput);
 
-#Removes the recipe allowing cobblestone to be changed into stone/grass
+// Removes the recipe allowing cobblestone to be changed into stone/grass
 mods.projecte.WorldTransmutation.remove(<blockstate:minecraft:stone>, <blockstate:minecraft:cobblestone>, <blockstate:minecraft:grass>); 
 ```
 

--- a/docs/Vanilla/Players/IPlayer.md
+++ b/docs/Vanilla/Players/IPlayer.md
@@ -11,7 +11,7 @@ It might be required for you to import the package if you encounter any issues (
 IPlayer extends [IEntityLivingBase](/Vanilla/Entities/IEntityLivingBase/). That means all functions available to [IEntityLivingBase](/Vanilla/Entities/IEntityLivingBase/) Objects also are available to IPlayer Objects.  
 IPlayer also extends [IUser](/Vanilla/Players/IUser/). That means all functions available to [IUser](/Vanilla/Players/IUser/) Objects also are available to IPlayer Objects.  
 
-##Zengetters
+## Zengetters
 
 Zengetters are for retrieving information. Usually either assigned to a variable or used in a method/function.
 
@@ -33,7 +33,7 @@ Zengetters are for retrieving information. Usually either assigned to a variable
 | foodStats     | returns the player's foodstats.                                                            | [IFoodStats](/Vanilla/Players/IFoodStats/)                 | `player.foodStats`     |
 
 
-##ZenMethods
+## ZenMethods
 
 Zenmethods are for doing things with other things, in this case with a player.
 


### PR DESCRIPTION
Some section headers were missing a space after the `#`. I believe I've caught them all with a search through all of the docs using this regex `^(#+)(?!loader|modloaded|debug|priority|packmode)(\w+)`.

I also noticed there were a few docs that used the `#` for comments, when in every other case `//` is used, so I've changed those as well.