### PR TITLE
feat(mod-docs): updated Thermal Expansion Refinery docs

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Refinery.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Refinery.md
@@ -41,7 +41,6 @@ Refinery.addRecipePotion(<liquid:potion>.withTag({Potion: "minecraft:mundane"}) 
 ## Removing a Recipe
 
 `Refinery.removeRecipe(input);`
-`Refinery.removeRecipePotion(input);`
 
 - `input` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
 
@@ -49,5 +48,16 @@ Refinery.addRecipePotion(<liquid:potion>.withTag({Potion: "minecraft:mundane"}) 
 import mods.thermalexpansion.Refinery;
 
 Refinery.removeRecipe(<liquid:resin>);
+```
+
+### Removing a Potion Recipe
+
+`Refinery.removeRecipePotion(input);`
+
+- `input` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+
+```zenscript
+import mods.thermalexpansion.Refinery;
+
 Refinery.removeRecipePotion(<liquid:potion_lingering>.withTag({Potion: "cofhcore:healing3"}));
 ```

--- a/docs/Mods/Modtweaker/ThermalExpansion/Refinery.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Refinery.md
@@ -3,18 +3,51 @@
 ## Package
 `mods.thermalexpansion.Refinery`
 
-## Addition
+## Adding a Recipe
+
+`Refinery.addRecipe(output, outputItem, input, energy);`
+
+- `output` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+- `outputItem` <[WeightedItemStack](/Vanilla/Items/WeightedItemStack)>
+- `input` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+- `energy` 	&lt;int> The total energy cost
 
 ```zenscript
-mods.thermalexpansion.Refinery.addRecipe(ILiquidStack output, IItemStack outputItem, ILiquidStack input, int energy);
+import mods.thermalexpansion.Refinery;
 
-mods.thermalexpansion.Refinery.addRecipe(<liquid:lava>, <minecraft:diamond>,<liquid:water>, 50);
+// Adds a recipe that outputs 1mB of lava and a diamond (at a 100% chance) per 1mB of water
+Refinery.addRecipe(<liquid:lava>, <minecraft:diamond>, <liquid:water>, 50);
+
+// Adds a recipe that outputs 5mB of lava and a diamond (at a 1% chance) per 100mB of water
+Refinery.addRecipe(<liquid:lava> * 5, <minecraft:diamond> % 1, <liquid:water> * 100, 50);
 ```
 
-## Removal
+### Adding a Potion Recipe
+
+Adds a recipe to be used with the Alchemical Retort Augmentation
+
+`Refinery.addRecipePotion(output, input, energy);`
+
+- `output` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+- `input` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+- `energy` 	&lt;int> The total energy cost
 
 ```zenscript
-mods.thermalexpansion.Refinery.removeRecipe(ILiquidStack input);
+import mods.thermalexpansion.Refinery;
 
-mods.thermalexpansion.Refinery.removeRecipe(<liquid:resin>);
+Refinery.addRecipePotion(<liquid:potion>.withTag({Potion: "minecraft:mundane"}) * 500, <liquid:potion>.withTag({Potion: "cofhcore:leaping4"}) * 100, 100);
+```
+
+## Removing a Recipe
+
+`Refinery.removeRecipe(input);`
+`Refinery.removeRecipePotion(input);`
+
+- `input` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)>
+
+```zenscript
+import mods.thermalexpansion.Refinery;
+
+Refinery.removeRecipe(<liquid:resin>);
+Refinery.removeRecipePotion(<liquid:potion_lingering>.withTag({Potion: "cofhcore:healing3"}));
 ```


### PR DESCRIPTION
The refinery docs had not been updated to show support for the WeightedItemStack.

In addition, I added documentation for recipes using the Alchemical Retort Augmentation (addRecipePotion and removeRecipePotion).