### PR TITLE
fix(nav): BuildCraft navigation incorrectly defined

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -271,9 +271,11 @@ nav:
         - Starlight Transmutation: 'Mods/Astral_Sorcery/Transmutation.md'
         - Util: 'Mods/Astral_Sorcery/Util.md'
     - BuildCraft:
-        - Home: 'Mods/BuildCraft/index.md'
-        - Crafting:
-            - 'Mods/BuildCraft/Crafting/AssemblyTable.md'
+      - Home: 'Mods/BuildCraft/index.md'
+      - Crafting:
+        - AssemblyTable: 'Mods/BuildCraft/Crafting/AssemblyTable.md'
+      - Energy:
+        - CombustionEngine: 'Mods/BuildCraft/Energy/CombustionEngine.md'
     - Calculator:
       - Algorithm Seperator: 'Mods/Calculator/Algorithm_Seperator.md'
       - Atomic Calculator: 'Mods/Calculator/Atomic_Calculator.md'


### PR DESCRIPTION
The navigation menu for the BuildCraft documentation was incorrectly defined.