### PR TITLE
fix(mods/buildcraft): invalid parameter type links

### DIFF
--- a/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
+++ b/docs/Mods/BuildCraft/Crafting/AssemblyTable.md
@@ -13,9 +13,9 @@ To use, import the class with `import mods.buildcraft.AssemblyTable;` at the beg
 `AssemblyTable.addRecipe(recipeName, output, power, inputs);`
 
 - `recipeName` (Optional) &lt;string> The name of the recipe. *Must be unique!*
-- `output` <[IItemStack](/vanilla/api/items/IItemStack)>
+- `output` <[IItemStack](/Vanilla/Items/IItemStack)>
 - `power` &lt;int> Total power cost in MJ
-- `inputs` <[IIngredient](/vanilla/api/items/IIngredient)[]>
+- `inputs` <[IIngredient](/Vanilla/Variable_Types/IIngredient)[]>
 
 ```zenscript
 import mods.buildcraft.AssemblyTable;

--- a/docs/Mods/BuildCraft/Energy/CombustionEngine.md
+++ b/docs/Mods/BuildCraft/Energy/CombustionEngine.md
@@ -12,7 +12,7 @@ To use, import the class with `import mods.buildcraft.CombustionEngine;` at the 
 
 `CombustionEngine.addCleanFuel(liquid, powerPerTick, timePerBucket);`
 
-- `liquid` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The liquid to be used as fuel
+- `liquid` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)> The liquid to be used as fuel
 - `powerPerTick` &lt;double> Power output in MJ per tick
 - `timePerBucket` &lt;int> Amount of ticks that 1,000 mB (1 bucket) should run for
 
@@ -26,10 +26,10 @@ CombustionEngine.addCleanFuel(<liquid:iron>, 32.0, 1200);
 
 `CombustionEngine.addDirtyFuel(lFuel, powerPerTick, timePerBucket, lResidue);`
 
-- `lFuel` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The liquid to be used as fuel
+- `lFuel` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)> The liquid to be used as fuel
 - `powerPerTick` &lt;double> Power output in MJ per tick
 - `timePerBucket` &lt;int> Amount of ticks that 1,000 mB (1 bucket) should run for
-- `lResidue` <[ILiquidStack](/vanilla/api/liquids/ILiquidStack)> The residue fluid, per bucket of the original fuel
+- `lResidue` <[ILiquidStack](/Vanilla/Liquids/ILiquidStack)> The residue fluid, per bucket of the original fuel
 
 ```zenscript
 import mods.buildcraft.CombustionEngine;


### PR DESCRIPTION
Links to the parameter types in the BuildCraft documentation (IItemStack, IIngredient, etc) were linking to incorrect locations. I had used the paths to the 1.14 versions accidentally.