### PR TITLE
feat(1.14/mods): add Botany Pots documentation

### DIFF
--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -162,6 +162,10 @@ Crop.removeDrop("botanypots:crop/wheat", <item:minecraft:wheat_seeds>);
 
 ## Getting All Ids
 
+`Crop.getAllIds();`
+
+- Returns: &lt;string[]> An array of all known crop ids at the time this is ran.
+
 This will give you an array of all the known crop ids at the time.
 
 ```zenscript

--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -1,0 +1,177 @@
+# Crops
+
+Class path: `mods.botanypots.Crop`
+
+## Use
+
+To use, import the class with `import mods.botanypots.Crop;` at the beginning of your script.
+
+***Growth multipliers no longer exist after MC 1.14.***
+
+## Create A Crop
+
+`Crop.create(id, seed, display, tickRate, multiplier, categories);`
+
+`Crop.create(id, seed, display, tickRate, categories);` (For MC 1.15+)
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `seed` <[IIngredient](/vanilla/api/items/IIngredient)> The item used to plant the crop.
+- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block to display when rendering the crop.
+- `tickRate` &lt;int> One of the factors for how long a crop takes to grow.
+- `multiplier` &lt;float> (Only in 1.14) Another factor for how long the crop takes to grow.
+- `categories` &lt;string[]> An array of soil categories this crop can be grown in.
+
+This can be used to create a new crop. Keep in mind that drops need to be added separately.
+
+```zenscript
+Crop.create("examplepack:gold", <item:minecraft:gold_nugget>, <blockstate:minecraft:gold_block>, 3000, 2, ["stone"]);
+```
+
+## Remove A Crop
+
+`Crop.remove(id);`
+
+- `id` &lt;string> The id of the crop to remove. This is a namespaced id an must be in the valid `namespace:path` format.
+
+Removes a crop based on it's id.
+
+```zenscript
+Crop.remove("botanypots:crop/wheat");
+```
+
+## Set Seed Item
+
+`Crop.setSeed(id, seed);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `seed` <[IIngredient](/vanilla/api/items/IIngredient)> The item used to plant the crop.
+
+Sets the item used to plant the crop.
+
+```zenscript
+Crop.setSeed("botanypots:crop/wheat", <item:minecraft:diamond>);
+```
+
+## Set Display Block
+
+`Crop.setDisplay(id, state);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block to display when rendering the crop.
+
+Sets the block rendered for the crop.
+
+```zenscript
+Crop.setDisplay("botanypots:crop/wheat", <blockstate:minecraft:snow_block>);
+```
+
+## Set Tick Rate
+
+`Crop.setTickRate(id, tickRate);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `tickRate` &lt;int> The updated tick rate. One of the factors for how long a crop takes to grow.
+
+Sets the crop tick factor.
+
+```zenscript
+Crop.setTickRate("botanypots:crop/wheat", 5000);
+```
+
+## Set Growth Multiplier
+
+`Crop.setGrowthModifier(id, multiplier);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `multiplier` &lt;float> The updated multiplier. Another factor for how long the crop takes to grow.
+
+Sets the growth multiplier/modifier for the crop.
+
+***Does not exist beyond 1.14!***
+
+```zenscript
+Crop.setGrowthMofieir("botanypots:crop/wheat", 1.8);
+```
+
+## Changing Crop Categories
+
+Changes the categories associated with the crop. Categories are used to match the valid soils to the crop.
+
+### Add a Category to a Crop
+
+`Crop.addCategory(id, categoriesToAdd);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `categoriesToAdd` &lt;string[]> An array of categories to associate with the crop.
+
+```zenscript
+Crop.addCategory("botanypots:crop/wheat", ["stone", "snow"]);
+```
+
+### Remove a Category From a Crop
+
+`Crop.removeCategory(id, categoriesToRemove);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+- `categoriesToRemove` &lt;string[]> An array of categories to dissociate with the crop.
+
+```zenscript
+Crop.removeCategory("botanypots:crop/wheat", ["dirt"]);
+```
+
+### Clear All Categories From a Crop
+
+`Crop.clearCategories(id);`
+
+- `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
+
+```zenscript
+Crop.clearCategories("botanypots:crop/wheat");
+```
+
+## Crop Drops
+
+### Adding Drops
+
+`Crop.addDrop(id, drop, chance, min, max);`
+
+- `id` &lt;string> The id of the crop to add a drop to. This is a namespaced id an must be in the valid `namespace:path` format.
+- `drop` <[IItemStack](/vanilla/api/items/IItemStack)> The item to drop.
+- `chance` &lt;float> The chance it drops.
+- `min` &lt;int> The min amount of that item to give.
+- `max` &lt;int> The max amount of that item to give.
+
+This adds a new potential drop to the crop.
+
+```zenscript
+Crop.addDrop("botanypots:crop/wheat", <item:minecraft:diamond>, 0.05, 1, 1);
+```
+
+### Removing Drops
+
+`Crop.removeDrop(id, toRemove);`
+
+- `id` &lt;string> The id of the crop to remove a drop from. This is a namespaced id an must be in the valid `namespace:path` format.
+- `toRemove` <[IIngredient](/vanilla/api/items/IIngredient)> The ingredient to match against for removal
+
+Removes any drops that have a matching item.
+
+```zenscript
+Crop.removeDrop("botanypots:crop/wheat", <item:minecraft:wheat_seeds>);
+```
+
+## Getting All Ids
+
+This will give you an array of all the known crop ids at the time.
+
+```zenscript
+Crop.getAllIds();
+```
+
+## Removing All Crops
+
+This will completely remove all the crops currently registered. This is useful for if you want to recreate all the data from scratch through scripts.
+
+```zenscript
+Crop.removeAll();
+```

--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -170,6 +170,11 @@ This will give you an array of all the known crop ids at the time.
 
 ```zenscript
 Crop.getAllIds();
+
+// Log all ids to the crafttweaker.log file
+for cropId in Crop.getAllIds() {
+    println(cropId);
+}
 ```
 
 ## Removing All Crops

--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -6,19 +6,15 @@ Class path: `mods.botanypots.Crop`
 
 To use, import the class with `import mods.botanypots.Crop;` at the beginning of your script.
 
-***Growth multipliers no longer exist after MC 1.14.***
-
 ## Create A Crop
 
 `Crop.create(id, seed, display, tickRate, multiplier, categories);`
-
-`Crop.create(id, seed, display, tickRate, categories);` (For MC 1.15+)
 
 - `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
 - `seed` <[IIngredient](/vanilla/api/items/IIngredient)> The item used to plant the crop.
 - `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState)> The block to display when rendering the crop.
 - `tickRate` &lt;int> One of the factors for how long a crop takes to grow.
-- `multiplier` &lt;float> (Only in 1.14) Another factor for how long the crop takes to grow.
+- `multiplier` &lt;float> Another factor for how long the crop takes to grow.
 - `categories` &lt;string[]> An array of soil categories this crop can be grown in.
 
 This can be used to create a new crop. Keep in mind that drops need to be added separately.
@@ -86,8 +82,6 @@ Crop.setTickRate("botanypots:crop/wheat", 5000);
 - `multiplier` &lt;float> The updated multiplier. Another factor for how long the crop takes to grow.
 
 Sets the growth multiplier/modifier for the crop.
-
-***Does not exist beyond 1.14!***
 
 ```zenscript
 Crop.setGrowthMofieir("botanypots:crop/wheat", 1.8);

--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -16,7 +16,7 @@ To use, import the class with `import mods.botanypots.Crop;` at the beginning of
 
 - `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
 - `seed` <[IIngredient](/vanilla/api/items/IIngredient)> The item used to plant the crop.
-- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block to display when rendering the crop.
+- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState)> The block to display when rendering the crop.
 - `tickRate` &lt;int> One of the factors for how long a crop takes to grow.
 - `multiplier` &lt;float> (Only in 1.14) Another factor for how long the crop takes to grow.
 - `categories` &lt;string[]> An array of soil categories this crop can be grown in.
@@ -57,7 +57,7 @@ Crop.setSeed("botanypots:crop/wheat", <item:minecraft:diamond>);
 `Crop.setDisplay(id, state);`
 
 - `id` &lt;string> The id of the crop. This is a namespaced id an must be in the valid `namespace:path` format.
-- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block to display when rendering the crop.
+- `display` <[MCBlockState](/vanilla/api/blocks/MCBlockState)> The block to display when rendering the crop.
 
 Sets the block rendered for the crop.
 

--- a/docs/mods/botanypots/Crop.md
+++ b/docs/mods/botanypots/Crop.md
@@ -169,8 +169,6 @@ Crop.removeDrop("botanypots:crop/wheat", <item:minecraft:wheat_seeds>);
 This will give you an array of all the known crop ids at the time.
 
 ```zenscript
-Crop.getAllIds();
-
 // Log all ids to the crafttweaker.log file
 for cropId in Crop.getAllIds() {
     println(cropId);

--- a/docs/mods/botanypots/Fertilizer.md
+++ b/docs/mods/botanypots/Fertilizer.md
@@ -1,0 +1,77 @@
+# Fertilizers
+
+Class path: `mods.botanypots.Fertilizer`
+
+## Use
+
+To use, import the class with `import mods.botanypots.Fertilizer;` at the beginning of your script.
+
+## Creating Fertilizers
+
+`Fertilizer.create(id, ingredient, minTick, maxTick);`
+
+- `id` &lt;string> The id of the new fertilizer. This is a namespaced id an must be in the valid `namespace:path` format.
+- `ingredient` <[IIngredient](/vanilla/api/items/IIngredient)> The item used for the fertilizer.
+- `minTick` &lt;int> The minimum amount of ticks added by the fertilizer.
+- `maxTick` &lt;int> The maximum amount of ticks added by the fertilizer.
+
+Creates a new fertilizer. These can be used to grow crops faster.
+
+```zenscript
+Fertilizer.create("examplepack:stick", <item:minecraft:stick>, 250, 550);
+```
+
+## Removing Fertilizers
+
+`Fertilizer.remove(id);`
+
+- `id` &lt;string> The id of the fertilizer. This is a namespaced id an must be in the valid `namespace:path` format.
+
+This can be used to remove a fertilizer.
+
+```zenscript
+Fertilizer.remove("botanypots:fertilizers/bone_meal");
+```
+
+## Changing Fertilizer Ticks
+
+`Fertilizer.setTicks(String id, int minTick, int maxTick);`
+
+- `id` &lt;string> The id of the fertilizer. This is a namespaced id an must be in the valid `namespace:path` format.
+- `minTick` &lt;int> The new minimum amount of ticks added by the fertilizer.
+- `maxTick` &lt;int> The new maximum amount of ticks added by the fertilizer.
+
+This will change the growth tick range added by the fertilizer.
+
+```zenscript
+Fertilizer.setTicks("botanypots:fertilizers/bone_meal", 800, 900);
+```
+
+## Changing Fertilizer Ingredients
+
+`Fertilizer.setIngredient(id, ingredient);`
+
+- `id` &lt;string> The id of the fertilizer. This is a namespaced id an must be in the valid `namespace:path` format.
+- `ingredient` <[IIngredient](/vanilla/api/items/IIngredient)> The new item to be used for the fertilizer.
+
+Sets the ingredient item that is the fertilizer.
+
+```zenscript
+Fertilizer.setIngredient("botanypots:fertilizers/bone_meal", <item:minecraft:sugar>);
+```
+
+## Getting All Ids
+
+This will give you an array of all the known fertilizer ids at the time.
+
+```zenscript
+Fertilizer.getAllIds();
+```
+
+## Removing All Fertilizers
+
+This will completely remove all the fertilizers currently registered. This is useful for if you want to recreate all the data from scratch through scripts.
+
+```zenscript
+Fertilizer.removeAll();
+```

--- a/docs/mods/botanypots/Fertilizer.md
+++ b/docs/mods/botanypots/Fertilizer.md
@@ -69,8 +69,6 @@ Fertilizer.setIngredient("botanypots:fertilizers/bone_meal", <item:minecraft:sug
 This will give you an array of all the known fertilizer ids at the time.
 
 ```zenscript
-Fertilizer.getAllIds();
-
 // Log all ids to the crafttweaker.log file
 for fertilizerId in Fertilizer.getAllIds() {
     println(fertilizerId);

--- a/docs/mods/botanypots/Fertilizer.md
+++ b/docs/mods/botanypots/Fertilizer.md
@@ -62,6 +62,10 @@ Fertilizer.setIngredient("botanypots:fertilizers/bone_meal", <item:minecraft:sug
 
 ## Getting All Ids
 
+`Fertilizer.getAllIds();`
+
+- Returns: &lt;string[]> An array of all known fertilizer ids at the time this is ran.
+
 This will give you an array of all the known fertilizer ids at the time.
 
 ```zenscript

--- a/docs/mods/botanypots/Fertilizer.md
+++ b/docs/mods/botanypots/Fertilizer.md
@@ -70,6 +70,11 @@ This will give you an array of all the known fertilizer ids at the time.
 
 ```zenscript
 Fertilizer.getAllIds();
+
+// Log all ids to the crafttweaker.log file
+for fertilizerId in Fertilizer.getAllIds() {
+    println(fertilizerId);
+}
 ```
 
 ## Removing All Fertilizers

--- a/docs/mods/botanypots/Soil.md
+++ b/docs/mods/botanypots/Soil.md
@@ -119,6 +119,11 @@ This will give you an array of all the known soil ids at the time.
 
 ```zenscript
 Soil.getAllIds();
+
+// Log all ids to the crafttweaker.log file
+for soilId in Soil.getAllIds() {
+    println(soilId);
+}
 ```
 
 ## Removing All Soil

--- a/docs/mods/botanypots/Soil.md
+++ b/docs/mods/botanypots/Soil.md
@@ -1,0 +1,126 @@
+# Soils
+
+Class path: `mods.botanypots.Soil`
+
+## Use
+
+To use, import the class with `import mods.botanypots.Soil;` at the beginning of your script.
+
+## Creating New Soils
+
+`Soil.create(id, ingredient, displayState, tickRate, categories);`
+
+- `id` &lt;string> The id of the new soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `ingredient` <[IIngredient](/vanilla/api/items/IIngredient)> The ingredient used to determine which items/blocks are used to put the soil in a pot.
+- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block state to display for the soil in the pot.
+- `tickRate` &lt;int> The tick rate for the soil.
+- `categories` &lt;string[]> An array of categories associated with the new soil.
+
+Creates a new soil entry that players can use in the botany pot.
+
+```zenscript
+Soil.create("examplepack:rock", <item:minecraft:stone>, <blockstate:minecraft:stone>, 100, ["rocky"]);
+```
+
+## Removing A Soil
+
+`Soil.remove(id);`
+
+- `id` &lt;string> The id of the soil to remove. This is a namespaced id an must be in the valid `namespace:path` format.
+
+Removes a soil from the game's data.
+
+```zenscript
+Soil.remove("botanypots:soil/podzol");
+```
+
+## Changing Soil Tick Rate
+
+`Soil.setTicks(id, tickRate);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `tickRate` &lt;int> The new tick rate for the soil.
+
+Changes the tick rate of a given soil.
+
+```zenscript
+Soil.setTicks("botanypots:soil/grass", 1300);
+```
+
+## Changing Soil Ingredient
+
+`Soil.setIngredient(id, ingredient);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `ingredient` <[IIngredient](/vanilla/api/items/IIngredient)> The ingredient used to determine which items/blocks are used to put the soil in a pot.
+
+Changes the items used to put the soil into the botany pot.
+
+```zenscript
+Soil.setIngredient("botanypots:soil/soul_sand", <item:minecraft:sand>);
+```
+
+## Changing Soil Display
+
+`Soil.setDisplayState(id, displayState);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block state to display for the soil in the pot.
+
+Changes the block displayed for the soil.
+
+```zenscript
+Soil.setDisplayState("botanypots:soil/dirt", <blockstate:minecraft:snow>);
+```
+
+## Changing Soil Categories
+
+Changes the categories associated with the soil. These are used to match crops to valid soils.
+
+### Add a Category to a Soil
+
+`Soil.addCategory(id, categoriesToAdd);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `categoriesToAdd` &lt;string[]> An array of categories to associate with the soil.
+
+```zenscript
+Soil.addCategory("botanypots:soil/soul_sand", ["nether"]);
+```
+
+### Remove a Category From a Soil
+
+`Soil.removeCategory(id, categoriesToRemove);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+- `categoriesToRemove` &lt;string[]> An array of categories to dissociate with the soil.
+
+```zenscript
+Soil.removeCategory("botanypots:soil/soul_sand", ["soul_sand"]);
+```
+
+### Clear All Categories From a Soil
+
+`Soil.clearCategories(id);`
+
+- `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
+
+```zenscript
+Soil.clearCategories("botanypots:soil/farmland");
+```
+
+## Getting All Ids
+
+This will give you an array of all the known soil ids at the time.
+
+```zenscript
+Soil.getAllIds();
+```
+
+## Removing All Soil
+
+This will completely remove all the soils currently registered. This is useful for if you want to recreate all the data from scratch through scripts.
+
+```zenscript
+Soil.removeAll();
+```

--- a/docs/mods/botanypots/Soil.md
+++ b/docs/mods/botanypots/Soil.md
@@ -118,8 +118,6 @@ Soil.clearCategories("botanypots:soil/farmland");
 This will give you an array of all the known soil ids at the time.
 
 ```zenscript
-Soil.getAllIds();
-
 // Log all ids to the crafttweaker.log file
 for soilId in Soil.getAllIds() {
     println(soilId);

--- a/docs/mods/botanypots/Soil.md
+++ b/docs/mods/botanypots/Soil.md
@@ -111,6 +111,10 @@ Soil.clearCategories("botanypots:soil/farmland");
 
 ## Getting All Ids
 
+`Soil.getAllIds();`
+
+- Returns: &lt;string[]> An array of all known soil ids at the time this is ran.
+
 This will give you an array of all the known soil ids at the time.
 
 ```zenscript

--- a/docs/mods/botanypots/Soil.md
+++ b/docs/mods/botanypots/Soil.md
@@ -12,7 +12,7 @@ To use, import the class with `import mods.botanypots.Soil;` at the beginning of
 
 - `id` &lt;string> The id of the new soil. This is a namespaced id an must be in the valid `namespace:path` format.
 - `ingredient` <[IIngredient](/vanilla/api/items/IIngredient)> The ingredient used to determine which items/blocks are used to put the soil in a pot.
-- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block state to display for the soil in the pot.
+- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState)> The block state to display for the soil in the pot.
 - `tickRate` &lt;int> The tick rate for the soil.
 - `categories` &lt;string[]> An array of categories associated with the new soil.
 
@@ -65,7 +65,7 @@ Soil.setIngredient("botanypots:soil/soul_sand", <item:minecraft:sand>);
 `Soil.setDisplayState(id, displayState);`
 
 - `id` &lt;string> The id of the soil. This is a namespaced id an must be in the valid `namespace:path` format.
-- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState.md)> The block state to display for the soil in the pot.
+- `displayState` <[MCBlockState](/vanilla/api/blocks/MCBlockState)> The block state to display for the soil in the pot.
 
 Changes the block displayed for the soil.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,10 @@ nav:
               - MCBiome: 'vanilla/api/world/MCBiome.md'
               - MCBiomeSpawnEntry: 'vanilla/api/world/MCBiomeSpawnEntry.md'
   - Mods:
+    - Botany Pots:
+      - Crop: 'mods/botanypots/Crop.md'
+      - Fertilizer: 'mods/botanypots/Fertilizer.md'
+      - Soil: 'mods/botanypots/Soil.md'
     - ContentTweaker:
       - Simple Walkthrough: 'mods/contenttweaker/SimpleWalkthrough.md'
       - API:


### PR DESCRIPTION
I took note of a difference in the 1.15 version of the mod compared to its 1.14 version. Hopefully that is clear enough for users.

As well, in a very few instances, sub-headers were added directly after a header (h2 -> h3 -> text) and the generated code from the Docs-Site causes both headings to show on a single line. This has been reported: https://github.com/CraftTweaker/Docs-Site/issues/1