### PR TITLE
fix(mods/CoT): incorrect method name for adding traits in example

### DIFF
--- a/docs/Mods/ContentTweaker/Tinkers_Construct/MaterialBuilder.md
+++ b/docs/Mods/ContentTweaker/Tinkers_Construct/MaterialBuilder.md
@@ -84,8 +84,8 @@ Possible values for `dependency` are:
 - `"fletching"`
 
 ```zenscript
-myMaterial.addTrait("fiery");
-myMaterial.addTrait("fiery", "bowstring");
+myMaterial.addMaterialTrait("fiery");
+myMaterial.addMaterialTrait("fiery", "bowstring");
 ```
 
 You can remove materialTraits as well (which is especially useful when doing batch materials).  


### PR DESCRIPTION
`addTrait` only exists as a method on a Material Representation which is returned after a Material is built. Prior to that point, the builder supports the same functionality with `addMaterialTrait`