### PR TITLE
fix(mods/modtweaker/te): incorrect parameter types in dynamos

### DIFF
--- a/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/EnervationDynamo.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/EnervationDynamo.md
@@ -10,13 +10,13 @@ import mods.thermalexpansion.EnervationDynamo;
 ## Add Fuel
 
 ```zenscript
-//mods.thermalexpansion.EnervationDynamo.addFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.EnervationDynamo.addFuel(<liquid:water>, 13);
+//mods.thermalexpansion.EnervationDynamo.addFuel(IItemStack stack, int energy);
+mods.thermalexpansion.EnervationDynamo.addFuel(<minecraft:stick>, 13);
 ```
 
 ## Remove Fuel
 
 ```zenscript
-//mods.thermalexpansion.EnervationDynamo.removeFuel(ILiquidStack stack);
-mods.thermalexpansion.EnervationDynamo.removeFuel(<liquid:water>);
+//mods.thermalexpansion.EnervationDynamo.removeFuel(IItemStack stack);
+mods.thermalexpansion.EnervationDynamo.removeFuel(<minecraft:stick>);
 ```

--- a/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/NumisticDynamo.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/NumisticDynamo.md
@@ -10,28 +10,28 @@ import mods.thermalexpansion.NumisticDynamo;
 ## Add Fuel
 
 ```zenscript
-//mods.thermalexpansion.NumisticDynamo.addFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.NumisticDynamo.addFuel(<liquid:water>, 13);
+//mods.thermalexpansion.NumisticDynamo.addFuel(IItemStack stack, int energy);
+mods.thermalexpansion.NumisticDynamo.addFuel(<minecraft:stick>, 13);
 ```
 
 ## Add Gem Fuel
 
 ```zenscript
-//mods.thermalexpansion.NumisticDynamo.addGemFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.NumisticDynamo.addGemFuel(<liquid:water>, 13);
+//mods.thermalexpansion.NumisticDynamo.addGemFuel(IItemStack stack, int energy);
+mods.thermalexpansion.NumisticDynamo.addGemFuel(<minecraft:stick>, 13);
 ```
 
 ## Remove Fuel
 
 ```zenscript
-//mods.thermalexpansion.NumisticDynamo.removeFuel(ILiquidStack stack);
-mods.thermalexpansion.NumisticDynamo.removeFuel(<liquid:water>);
+//mods.thermalexpansion.NumisticDynamo.removeFuel(IItemStack stack);
+mods.thermalexpansion.NumisticDynamo.removeFuel(<minecraft:stick>);
 ```
 
 
 ## Remove Gem Fuel
 
 ```zenscript
-//mods.thermalexpansion.NumisticDynamo.removeGemFuel(ILiquidStack stack);
-mods.thermalexpansion.NumisticDynamo.removeGemFuel(<liquid:water>);
+//mods.thermalexpansion.NumisticDynamo.removeGemFuel(IItemStack stack);
+mods.thermalexpansion.NumisticDynamo.removeGemFuel(<minecraft:stick>);
 ```

--- a/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/SteamDynamo.md
+++ b/docs/Mods/Modtweaker/ThermalExpansion/Dynamos/SteamDynamo.md
@@ -10,13 +10,13 @@ import mods.thermalexpansion.SteamDynamo;
 ## Add Fuel
 
 ```zenscript
-//mods.thermalexpansion.SteamDynamo.addFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.SteamDynamo.addFuel(<liquid:water>, 13);
+//mods.thermalexpansion.SteamDynamo.addFuel(IItemStack stack, int energy);
+mods.thermalexpansion.SteamDynamo.addFuel(<minecraft:stick>, 13);
 ```
 
 ## Remove Fuel
 
 ```zenscript
-//mods.thermalexpansion.SteamDynamo.removeFuel(ILiquidStack stack);
-mods.thermalexpansion.SteamDynamo.removeFuel(<liquid:water>);
+//mods.thermalexpansion.SteamDynamo.removeFuel(IItemStack stack);
+mods.thermalexpansion.SteamDynamo.removeFuel(<minecraft:stick>);
 ```


### PR DESCRIPTION
The parameter types for the Enervation, Numistic, and Steam Dynamos from Thermal Expansion had the incorrect parameter type documented. Rather than taking an `ILiquidStack`, they take a `IItemStack`.