### PR TITLE
Implement documentation merging for Project Exported Docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,11 @@
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
+    "merge-json": {
+      "version": "0.1.0-b.3",
+      "resolved": "https://registry.npmjs.org/merge-json/-/merge-json-0.1.0-b.3.tgz",
+      "integrity": "sha1-RI4RhCTHdSryrcqD+7BJdYWWpoA="
+    },
     "parse-entities": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,37 +1,40 @@
 {
-	"name": "crafttweaker-documentation",
-	"version": "1.0.0",
-	"description": "Documentation for the CraftTweaker project",
-	"private": true,
-	"main": "tools/build.ts",
-	"scripts": {
-		"build": "tsc && node out/build.js",
-		"test": "tsc && node out/test.js",
-        "generate-reverse-lookup": "tsc && node out/generate_reverse_lookup.js",
-		"serve": "tsc && node out/generate_reverse_lookup.js && node out/serve.js"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/CraftTweaker/CraftTweaker-Documentation.git"
-	},
-	"author": "Jaredlll08",
-	"license": "MIT",
-	"bugs": {
-		"url": "https://github.com/CraftTweaker/CraftTweaker-Documentation/issues"
-	},
-	"homepage": "https://github.com/CraftTweaker/CraftTweaker-Documentation#readme",
-	"devDependencies": {
-		"@types/fs-extra": "^9.0.1",
-		"@types/node": "^14.0.5",
-		"@types/lunr": "^2.3.3",
-		"ts-node": "^8.10.1",
-		"typescript": "^3.9.3",
-		"fs-extra": "^9.0.0",
-		"dotenv": "^8.2.0",
-		"lunr": "^2.3.8",
-		"remark-parse": "^8.0.2",
-		"to-vfile": "^6.1.0",
-		"unified": "^9.0.0",
-		"cross-env": "^7.0.2"
-	}
+  "name": "crafttweaker-documentation",
+  "version": "1.0.0",
+  "description": "Documentation for the CraftTweaker project",
+  "private": true,
+  "main": "tools/build.ts",
+  "scripts": {
+    "build": "tsc && node out/build.js",
+    "test": "tsc && node out/test.js",
+    "generate-reverse-lookup": "tsc && node out/generate_reverse_lookup.js",
+    "serve": "tsc && node out/generate_reverse_lookup.js && node out/serve.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CraftTweaker/CraftTweaker-Documentation.git"
+  },
+  "author": "Jaredlll08",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/CraftTweaker/CraftTweaker-Documentation/issues"
+  },
+  "homepage": "https://github.com/CraftTweaker/CraftTweaker-Documentation#readme",
+  "devDependencies": {
+    "@types/fs-extra": "^9.0.1",
+    "@types/node": "^14.0.5",
+    "@types/lunr": "^2.3.3",
+    "ts-node": "^8.10.1",
+    "typescript": "^3.9.3",
+    "fs-extra": "^9.0.0",
+    "dotenv": "^8.2.0",
+    "lunr": "^2.3.8",
+    "remark-parse": "^8.0.2",
+    "to-vfile": "^6.1.0",
+    "unified": "^9.0.0",
+    "cross-env": "^7.0.2"
+  },
+  "dependencies": {
+    "merge-json": "0.1.0-b.3"
+  }
 }

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -195,11 +195,11 @@ const build = async () => {
                 let dstDir = path.join(buildsDir, path.join(lang, "docs"));
                 let dupes = checkForDuplicates(docsDir, dstDir, true);
                 if (dupes.length > 0) {
-                    console.error(`Duplicate files were identified: docs merging cannot proceed!`);
-                    throw new Error(`Duplicate files were identified for language ${lang}: ${dupes}`);
+                    console.error(`Duplicate files were identified for language ${lang}: docs merging will ignore these files!`);
+                    console.error(`Found files: ${dupes}`);
                 }
 
-                fs.copySync(docsDir, path.join(buildsDir, path.join(lang, "docs")), { overwrite: false, errorOnExist: true });
+                fs.copySync(docsDir, path.join(buildsDir, path.join(lang, "docs")), { overwrite: false, errorOnExist: false });
 
                 if (fs.existsSync(docsJson)) {
                     languageJsons.push(docsJson);

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -141,26 +141,6 @@ const buildIndex = (folder: string) => {
 
 };
 
-const attemptMerge = (buildsDir: string, exportedDocs: string, dirs: string[]): string[] => {
-    let foundJsons: string[] = [];
-    dirs.forEach(relativeDir => {
-        let dir: string = path.join(exportedDocs, relativeDir);
-        fs.copySync(dir, buildsDir);
-        let fileList: string[] = [];
-        listFiles(dir, fileList, ["json"]);
-        let json = fileList.find((value: string, _i: number, _obj: string[]) => {
-            return value.endsWith("docs.json");
-        });
-        if (json !== undefined) {
-            fs.removeSync(path.join(buildsDir, 'docs.json'));
-            foundJsons.push(json);
-        } else {
-            console.error(`Directory '` + dir + `' does not define any 'docs.json' files: check your build script`);
-        }
-    });
-    return foundJsons;
-};
-
 const doJsonMerge = (jsonPaths: string[]): any => {
     let json: any = {};
     jsonPaths.forEach((path: string) => {

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -114,7 +114,7 @@ const buildIndex = (folder: string) => {
         });
     });
     if(linkError){
-        throw "Link check failed!";
+        throw new Error("Link check failed!");
     }
     // Convert to relative links that we can use
     docs = docs.map(value => {

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -244,17 +244,18 @@ const build = async () => {
 
     console.log("Copying files to folders");
     if (process.env.docsSiteDir === undefined || process.env.VERSION === undefined) {
-        throw new Error(`Unable to copy files because variables are missing! docsSiteDir is '${process.env.docsSiteDir}', VERSION is '${process.env.VERSION}'`);
+        console.log(`Unable to deploy build because variables are missing! docsSiteDir is '${process.env.docsSiteDir}', VERSION is '${process.env.VERSION}'`);
+    } else {
+        let docsPath = path.join(process.env.docsSiteDir, process.env.VERSION);
+        if (fs.existsSync(docsPath)) {
+            // can't remove a non empty dir?
+            fs.emptyDirSync(docsPath);
+            fs.rmdirSync(docsPath);
+        }
+        fs.mkdirSync(docsPath);
+        fs.copySync(buildsDir, docsPath);
+        console.log("Copied files!")
     }
-    let docsPath = path.join(process.env.docsSiteDir, process.env.VERSION);
-    if (fs.existsSync(docsPath)) {
-        // can't remove a non empty dir?
-        fs.emptyDirSync(docsPath);
-        fs.rmdirSync(docsPath);
-    }
-    fs.mkdirSync(docsPath);
-    fs.copySync(buildsDir, docsPath);
-    console.log("Copied files!")
 };
 
 

--- a/tools/build.ts
+++ b/tools/build.ts
@@ -17,6 +17,7 @@ let lunr = require("lunr");
 let unified = require('unified');
 let markdown = require('remark-parse');
 let vfile = require('to-vfile');
+let mergeJson = require("merge-json");
 
 interface Doc {
     location: string,
@@ -24,11 +25,10 @@ interface Doc {
     text: string
 }
 
-
 const buildIndex = (folder: string) => {
 
     let fileList: string[] = [];
-    listFiles(folder, fileList);
+    listFiles(folder, fileList, ["md"]);
 
     let processor = unified().use(markdown, {});
     let docs: Doc[] = [];
@@ -141,20 +141,101 @@ const buildIndex = (folder: string) => {
 
 };
 
+const attemptMerge = (buildsDir: string, exportedDocs: string, dirs: string[]): string[] => {
+    let foundJsons: string[] = [];
+    dirs.forEach(relativeDir => {
+        let dir: string = path.join(exportedDocs, relativeDir);
+        fs.copySync(dir, buildsDir);
+        let fileList: string[] = [];
+        listFiles(dir, fileList, ["json"]);
+        let json = fileList.find((value: string, _i: number, _obj: string[]) => {
+            return value.endsWith("docs.json");
+        });
+        if (json !== undefined) {
+            fs.removeSync(path.join(buildsDir, 'docs.json'));
+            foundJsons.push(json);
+        } else {
+            console.error(`Directory '` + dir + `' does not define any 'docs.json' files: check your build script`);
+        }
+    });
+    return foundJsons;
+};
+
+const doJsonMerge = (jsonPaths: string[]): any => {
+    let json: any = {};
+    jsonPaths.forEach((path: string) => {
+        let jsonText = fs.readFileSync(path, 'utf8');
+        json = mergeJson.merge(json, JSON.parse(jsonText));
+        console.log(`Merged file '${path}'`);
+    });
+    return json;
+}
+
 const build = async () => {
     let buildsDir = path.join(process.cwd(), `build`);
+    let exportedDocsDir = path.join(process.cwd(), `docs_exported`);
     let translationsDir = path.join(process.cwd(), `translations`);
+    let exportedTranslationsDir = path.join(process.cwd(), `translations_exported`);
+
     console.log(`Creating or emptying build directory!`);
     fs.emptyDirSync(buildsDir);
+
     console.log(`Copying translations!`);
     fs.copySync(translationsDir, buildsDir);
     fs.removeSync(path.join(buildsDir, `en`));
     fs.mkdirsSync(path.join(buildsDir, path.join("en", "docs")));
     fs.copySync("docs", path.join(buildsDir, path.join("en", "docs")));
-    fs.copySync("mkdocs.yml", path.join(buildsDir, path.join(`en`, "mkdocs.yml")));
-    fs.copySync("docs.json", path.join(buildsDir, path.join(`en`, "docs.json")));
+    fs.copySync("mkdocs.yml", path.join(buildsDir, path.join("en", "mkdocs.yml")));
+    fs.copySync("docs.json", path.join(buildsDir, path.join("en", "docs.json")));
+    console.log(`Copied translations!`);
+
     let languages = getLanguages(buildsDir);
-    console.log("Building Search indices and reverse doc lookup");
+    const findDirectoryForLang = (lang: string, docs: string, translation: string): string => {
+        if (lang == `en`) return docs;
+        return path.join(translation, path.join(lang, `docs_exported`));
+    };
+    const findUserJsonForLang = (lang: string, translation: string): string => {
+        if (lang == `en`) return `docs.json`;
+        return path.join(translation, path.join(lang, `docs.json`))
+    }
+
+    console.log("Merging automated export files");
+    languages.forEach(lang => {
+        let docsExportedDirectoryForLang = findDirectoryForLang(lang, exportedDocsDir, exportedTranslationsDir);
+
+        console.log(`Copying translated files for language '${lang}' to output directory`);
+        let exportsSubDirs: string[] = fs.readdirSync(docsExportedDirectoryForLang);
+        let languageJsons: string[] = [];
+        exportsSubDirs.forEach(subDirectory => {
+            let docsDir = path.join(docsExportedDirectoryForLang, path.join(subDirectory, "docs"));
+            let docsJson = path.join(docsExportedDirectoryForLang, path.join(subDirectory, "docs.json"));
+
+            if (fs.existsSync(docsDir)) {
+                fs.copySync(docsDir, path.join(buildsDir, path.join(lang, "docs")), { overwrite: false, errorOnExist: true });
+
+                if (fs.existsSync(docsJson)) {
+                    languageJsons.push(docsJson);
+                } else {
+                    console.error(`Directory ${docsDir} does not define any 'docs.json' files: check your automated export script!`);
+                }
+            } else {
+                console.log(`Subdirectory ${subDirectory} does not host docs for language ${lang}: skipping`);
+            }
+        });
+
+        let mainJson = findUserJsonForLang(lang, translationsDir);
+        if (fs.existsSync(mainJson)) {
+            languageJsons.push(findUserJsonForLang(lang, translationsDir));
+        } else {
+            console.error(`Language ${lang} does not define a main 'docs.json' in directory ${mainJson}: this is a serious error!`);
+        }
+
+        console.log(`Merging 'docs.json' files for language '${lang}': found ${languageJsons.length} files`);
+        let mergedJson: any = doJsonMerge(languageJsons);
+        fs.writeFileSync(path.join(buildsDir, path.join(lang, "docs.json")), JSON.stringify(mergedJson));
+    });
+
+    console.log("Building Search indices and reverse index lookup");
     languages.forEach(lang => {
         buildIndex(path.join(buildsDir, lang));
         console.log(`Done building an index for: "${lang}"`);
@@ -165,6 +246,9 @@ const build = async () => {
     });
 
     console.log("Copying files to folders");
+    if (process.env.docsSiteDir === undefined || process.env.VERSION === undefined) {
+        throw new Error(`Unable to copy files because variables are missing! docsSiteDir is '${process.env.docsSiteDir}', VERSION is '${process.env.VERSION}'`);
+    }
     let docsPath = path.join(process.env.docsSiteDir, process.env.VERSION);
     if (fs.existsSync(docsPath)) {
         // can't remove a non empty dir?
@@ -177,9 +261,10 @@ const build = async () => {
 };
 
 
-build().then(value => {
+build().then(_value => {
     console.log(`Build done!`);
 }).catch(reason => {
-    console.log(`Build failed! Reason: "${reason}"`);
+    console.error(`Build failed! Reason: "${reason}"`);
+    console.error(reason.stack);
     process.exit(1);
 });

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -15,7 +15,7 @@ import {
 const testLinks = (folder: string, useDocsDir: boolean = false) => {
 
     let fileList: string[] = [];
-    listFiles(folder, fileList);
+    listFiles(folder, fileList, ["md"]);
 
     let processor = unified().use(markdown, {});
     let linkError: boolean = false;

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -15,7 +15,7 @@ import {
 const testLinks = (folder: string, useDocsDir: boolean = false) => {
 
     let fileList: string[] = [];
-    listFiles(folder, fileList, ["md"]);
+    listFiles(folder, fileList, true, ["md"]);
 
     let processor = unified().use(markdown, {});
     let linkError: boolean = false;

--- a/tools/util.ts
+++ b/tools/util.ts
@@ -1,15 +1,21 @@
 let fs = require('fs');
 let path = require('path');
 
-export const listFiles = (dir: string, filelist: string[]) => {
+export const listFiles = (dir: string, filelist: string[], extensionFilters: string[]) => {
+    let shouldFilter = extensionFilters.length > 0;
     let files = fs.readdirSync(dir);
     filelist = filelist || [];
     files.forEach(function (file: string) {
         if (fs.statSync(path.join(dir, file)).isDirectory()) {
-            filelist = listFiles(path.join(dir, file) + '/', filelist);
+            filelist = listFiles(path.join(dir, file) + '/', filelist, extensionFilters);
         } else {
-            if (file.endsWith(".md"))
+            if (!shouldFilter) {
                 filelist.push(path.join(dir, file));
+            } else {
+                for (let filter of extensionFilters) {
+                    if (file.endsWith("." + filter)) filelist.push(path.join(dir, file))
+                }
+            }
         }
     });
     return filelist;


### PR DESCRIPTION
This PR aims to implement the required steps needed to merge the autogenerated docs with the manually written ones, along with their translations, as discussed on Discord.

Given a set of exported docs, with their respective index files (`docs.json`), these files are automatically merged together into a single build directory and a single `docs.json` is generated containing links to those files. Ordering isn't considered during this generation.
Moreover, this PR allows both a fail-fast and a fail-gracefully approach in case of duplicate files.
