### PR TITLE
Fix the example given here to reflect reality

### DIFF
--- a/docs_exported/crafttweaker/docs/vanilla/api/items/IItemStack.md
+++ b/docs_exported/crafttweaker/docs/vanilla/api/items/IItemStack.md
@@ -291,7 +291,7 @@ Return Type: [IItemStack](/vanilla/api/items/IItemStack)
 
 ```zenscript
 IItemStack.withTag(tag as IData) as IItemStack
-<item:minecraft:dirt>.withTag({Display: {lore: ["Hello"]}});
+<item:minecraft:dirt>.withTag({Display: {lore: ["{ \"text\": \"Hello\" }"]}});
 ```
 
 | Parameter | Type | Description |


### PR DESCRIPTION
After doing a bit of testing it turns out that to add Lore properly, you need to use the same format for the text as is used for text in any other section of the 'display' NBT.

This might be able to be side-stepped by using MCTextComponent, but has not been tested.

Without the given formatting the 'Lore' never displays and.

Shown by the following code:

import crafttweaker.api.item.IItemStack;

craftingTable.addShapeless(
"test",
<item:minecraft:dirt>,
[<item:minecraft:dirt>],
(usualOut as IItemStack, inputs as IItemStack[]) => { return usualOut.copy().withTag({display: { Lore: [ "{\"text\": \"Test Text\"}" ], Name: "{\"text\": \"TEST!\"}" } }); });