### PR TITLE
Correct distillation tower recipe

### DIFF
--- a/docs/Mods/Immersive_Petroleum/CraftTweaker_Support/Distillation.md
+++ b/docs/Mods/Immersive_Petroleum/CraftTweaker_Support/Distillation.md
@@ -9,7 +9,7 @@ The Distillation "addRecipe" method consists of:
 |Output            |[Fluidstack](/Vanilla/Liquids/ILiquidStack/) Array[]|
 |Output            |[ItemStack](/Vanilla/Items/IItemStack/) Array[]     |
 |Input             |[Fluidstack](/Vanilla/Liquids/ILiquidStack/)        |
-|Flux/t            |Integer                                            |
+|Energy            |Integer                                            |
 |Time in Ticks     |Integer                                            |
 |Chance            |Float Array []                                     |
 


### PR DESCRIPTION
The distillation tower recipe expects the energy to be the total energy for the operation, not the energy per tick.  I've tested this in 1.12.2 (hence the pull request against `master`).  I don't know whether the same applies in other versions.