### PR TITLE
addDrillLaserRecipe() is not used.

### DIFF
--- a/docs/1.12/content/Mods/PneumaticCraft_Repressurized/Assembly.md
+++ b/docs/1.12/content/Mods/PneumaticCraft_Repressurized/Assembly.md
@@ -35,11 +35,13 @@ mods.pneumaticcraft.assembly.removeAllDrillLaserRecipes();
 These functions are used to add new recipes for the assembly system:
 
 ```zenscript
-mods.pneumaticcraft.assembly.addLaserRecipe(IItemStack input, IItemStack output)
-mods.pneumaticcraft.assembly.addDrillRecipe(IItemStack input, IItemStack output)
-mods.pneumaticcraft.assembly.addDrillLaserRecipe(IItemStack input, IItemStack output)
+mods.pneumaticcraft.assembly.addLaserRecipe(IItemStack input, IItemStack output);
+mods.pneumaticcraft.assembly.addDrillRecipe(IItemStack input, IItemStack output);
+
 
 // Examples
 mods.pneumaticcraft.assembly.addLaserRecipe(<pneumaticcraft:ingot_iron_compressed> * 2, <pneumaticcraft:compressed_iron_gear>);
 ```
+
+Combined drill/laser recipe are automatically added when a drill recipe goes from Item A -> Item B, and a laser recipe from Item B -> Item C.
 


### PR DESCRIPTION
addDrillLaserRecipe() does not do anything as pointed here: TeamPneumatic/pnc-repressurized/issues/418

- Added a short explanation on how a drill + laser recipe works
- Fixed a few missing semicolons

Note: Although drill + laser recipe works, it doesn't appear to show on JEI.