### PR TITLE
Fix Traits bracket handler docs

### DIFF
--- a/docs/1.12/content/Mods/CompatSkills/Requirements/Requirement_Types/Traits.md
+++ b/docs/1.12/content/Mods/CompatSkills/Requirements/Requirement_Types/Traits.md
@@ -4,10 +4,10 @@ Traits are similar to Skills in the way that we've moved them over to a Resource
 The Trait Syntax is as follows:
 ```
 Example:
-trait|ResourceLocation
+unlockable|ResourceLocation
 
 Working Example:
-trait|reskillable:battle_spirit
+unlockable|reskillable:battle_spirit
 ```
 
 You can find the Traits's ResourceLocations under:

--- a/docs/1.12/content/Mods/CompatSkills/Requirements/Requirement_Types/Traits.md
+++ b/docs/1.12/content/Mods/CompatSkills/Requirements/Requirement_Types/Traits.md
@@ -4,10 +4,10 @@ Traits are similar to Skills in the way that we've moved them over to a Resource
 The Trait Syntax is as follows:
 ```
 Example:
-unlockable|ResourceLocation
+trait|ResourceLocation
 
 Working Example:
-unlockable|reskillable:battle_spirit
+trait|reskillable:battle_spirit
 ```
 
 You can find the Traits's ResourceLocations under:

--- a/docs/1.12/content/Mods/CompatSkills/Supports/Reskillable/BracketHandlers.md
+++ b/docs/1.12/content/Mods/CompatSkills/Supports/Reskillable/BracketHandlers.md
@@ -14,8 +14,8 @@
 ### Trait Bracket Handler:
 ```
 ## Example:
-<trait:resourcelocation>
+<unlockable:resourcelocation>
 
 ## Working Example:
-<trait:reskillable:sidestep>
+<unlockable:reskillable:sidestep>
 ```


### PR DESCRIPTION
It took me a while to figure out why this wasn't working in my server, but after some testing, it turns traits are in fact needed to be referenced with an `unlockable` prefix.