### PR TITLE
Update examples for Thermal Expansion dynamo documentation

### DIFF
--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/CompressionDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/CompressionDynamo.md
@@ -11,8 +11,10 @@ import mods.thermalexpansion.CompressionDynamo;
 
 ```zenscript
 //mods.thermalexpansion.CompressionDynamo.addFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.CompressionDynamo.addFuel(<liquid:water>, 13);
+mods.thermalexpansion.CompressionDynamo.addFuel(<liquid:water>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `10000` and `200000000`.
 
 ## Remove Fuel
 

--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/EnervationDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/EnervationDynamo.md
@@ -11,8 +11,10 @@ import mods.thermalexpansion.EnervationDynamo;
 
 ```zenscript
 //mods.thermalexpansion.EnervationDynamo.addFuel(IItemStack stack, int energy);
-mods.thermalexpansion.EnervationDynamo.addFuel(<minecraft:stick>, 13);
+mods.thermalexpansion.EnervationDynamo.addFuel(<minecraft:stick>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `2000` and `200000000`.
 
 ## Remove Fuel
 

--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/MagmaticDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/MagmaticDynamo.md
@@ -11,8 +11,10 @@ import mods.thermalexpansion.MagmaticDynamo;
 
 ```zenscript
 //mods.thermalexpansion.MagmaticDynamo.addFuel(ILiquidStack stack, int energy);
-mods.thermalexpansion.MagmaticDynamo.addFuel(<liquid:water>, 13);
+mods.thermalexpansion.MagmaticDynamo.addFuel(<liquid:water>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `10000` and `200000000`.
 
 ## Remove Fuel
 

--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/NumisticDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/NumisticDynamo.md
@@ -11,15 +11,19 @@ import mods.thermalexpansion.NumisticDynamo;
 
 ```zenscript
 //mods.thermalexpansion.NumisticDynamo.addFuel(IItemStack stack, int energy);
-mods.thermalexpansion.NumisticDynamo.addFuel(<minecraft:stick>, 13);
+mods.thermalexpansion.NumisticDynamo.addFuel(<minecraft:stick>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `2000` and `200000000`.
 
 ## Add Gem Fuel
 
 ```zenscript
 //mods.thermalexpansion.NumisticDynamo.addGemFuel(IItemStack stack, int energy);
-mods.thermalexpansion.NumisticDynamo.addGemFuel(<minecraft:stick>, 13);
+mods.thermalexpansion.NumisticDynamo.addGemFuel(<minecraft:stick>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `2000` and `200000000`.
 
 ## Remove Fuel
 

--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/ReactantDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/ReactantDynamo.md
@@ -11,15 +11,19 @@ import mods.thermalexpansion.ReactantDynamo;
 
 ```zenscript
 //mods.thermalexpansion.ReactantDynamo.addReaction(IItemStack item, ILiquidStack liquid, int energy);
-mods.thermalexpansion.ReactantDynamo.addReaction(<minecraft:bedrock>, <liquid:water>, 13);
+mods.thermalexpansion.ReactantDynamo.addReaction(<minecraft:bedrock>, <liquid:water>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `10000` and `200000000`.
 
 ## Add Elemental Reaction
 
 ```zenscript
 //mods.thermalexpansion.ReactantDynamo.addReactionElemental(IItemStack item, ILiquidStack liquid, int energy);
-mods.thermalexpansion.ReactantDynamo.addReactionElemental(<minecraft:bedrock>, <liquid:water>, 13);
+mods.thermalexpansion.ReactantDynamo.addReactionElemental(<minecraft:bedrock>, <liquid:water>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `10000` and `200000000`.
 
 ## Remove Reaction
 

--- a/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/SteamDynamo.md
+++ b/docs/1.12/content/Mods/Modtweaker/ThermalExpansion/Dynamos/SteamDynamo.md
@@ -11,8 +11,10 @@ import mods.thermalexpansion.SteamDynamo;
 
 ```zenscript
 //mods.thermalexpansion.SteamDynamo.addFuel(IItemStack stack, int energy);
-mods.thermalexpansion.SteamDynamo.addFuel(<minecraft:stick>, 13);
+mods.thermalexpansion.SteamDynamo.addFuel(<minecraft:stick>, 20000);
 ```
+
+Note: The `energy` parameter needs to be a value between `2000` and `200000000`.
 
 ## Remove Fuel
 


### PR DESCRIPTION
Updated examples for all Modtweakers' Thermal Expansion dynamo v1.12 documentation pages by replacing dynamo energy output example parameters with valid values. This reflects the limited ranges of energy supported by each dynamo to avoid potential confusion. The minimum and maximum energy limits have also been included. Fixes #410.