### PR TITLE
Update getting_started.md: Replace ".zs prefix" with ".zs suffix"

### DIFF
--- a/docs/1.12/content/Getting_Started.md
+++ b/docs/1.12/content/Getting_Started.md
@@ -15,7 +15,7 @@ In addition to the core functionality provided to support Vanilla minecraft, mod
 
 Scripts are stored in `<minecraftdir>/scripts` and are loaded in the `PreInitialization` phase of Minecraft, unlike previous versions of CraftTweaker, Scripts cannot be reloaded, this is due to changes that Mojang have made in 1.12 and there is no workaround. Also, Scripts need to be on **both, the server AND the client instance** to work
 
-Script files have the `.zs` prefix and can be compressed into a `.zip` that will also be read.
+Script files have the `.zs` suffix and can be compressed into a `.zip` that will also be read.
 
 ### Writing your first script
 

--- a/docs/1.14/content/getting_started.md
+++ b/docs/1.14/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 

--- a/docs/1.15/content/getting_started.md
+++ b/docs/1.15/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 

--- a/docs/1.16/content/getting_started.md
+++ b/docs/1.16/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 

--- a/docs/1.17/content/getting_started.md
+++ b/docs/1.17/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 

--- a/docs/1.18/content/getting_started.md
+++ b/docs/1.18/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 

--- a/docs/1.19/content/getting_started.md
+++ b/docs/1.19/content/getting_started.md
@@ -5,7 +5,7 @@ CraftTweaker uses a custom scripting Language called `ZenScript`, ZenScript is r
 ZenScript is a "top down" scripting language, meaning that, `Imports` need to be at the top of the file, `Variable Declarations` should be near the top of the file, however there are no restrictions to that, a `Variable` can be defined anywhere in a script, however it will not be accessible to the lines above the `Variable` declaration.
 
 
-Script files have the `.zs` prefix, make sure that it isn't `.zs.txt`!
+Script files have the `.zs` suffix, make sure that it isn't `.zs.txt`!
 
 ## What are scripts
 


### PR DESCRIPTION
```
prefix
noun
a word, letter, or number placed before another.
"the Institute was granted the prefix ‘Royal’ in 1961"
```
File extensions are at the end of the file name, not the start, thus a suffix and not a prefix