### PR TITLE
[1.19.4] Documentation for The Aether mod.

### DIFF
--- a/docs/1.19.4/docs.json
+++ b/docs/1.19.4/docs.json
@@ -30,6 +30,7 @@
         "Mods": {
             "Initialinventory" : {},
             "PackMode": {},
+            "The Aether": {},
             "Generic Recipe Manipulation": "mods/other_mods.md"
         },
         "ZenCode": {

--- a/docs_exported/1.19.4/aether/docs.json
+++ b/docs_exported/1.19.4/aether/docs.json
@@ -1,0 +1,11 @@
+{
+  "nav": {
+    "Mods": {
+      "The Aether": {
+        "AltarFuelManager": "mods/aether/AltarFuelManager.md",
+        "FreezerFuelManager": "mods/aether/FreezerFuelManager.md",
+        "IncubatorFuelManager": "mods/aether/IncubatorFuelManager.md"
+      }
+    }
+  }
+}

--- a/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.json
@@ -1,0 +1,5 @@
+{
+  "path": "mods/aether/AltarFuelManager.md",
+  "zenCodeName": "mods.aether.AltarFuelManager",
+  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+}

--- a/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.json
@@ -1,5 +1,5 @@
 {
   "path": "mods/aether/AltarFuelManager.md",
   "zenCodeName": "mods.aether.AltarFuelManager",
-  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+  "searchTerms": [ "addFuel", "removeFuel" ]
 }

--- a/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
@@ -14,65 +14,29 @@ import mods.aether.AltarFuelManager;
 Adds this item as fuel for the Altar with the given burn time.
 
 ```zenscript
-// AltarFuelManager.addFuel(item as IItemStack, burnTime as int)
+// AltarFuelManager.addFuel(ingredient as IIngredient, burnTime as int)
 mods.aether.AltarFuelManager.addFuel(<item:minecraft:coal>, 250);
+mods.aether.AltarFuelManager.addFuel(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 | burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=addFuelTag}
-
-Adds the items from this tag as fuel for the Altar with the given burn time.
-
-```zenscript
-// AltarFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-mods.aether.AltarFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
 
 :::group{name=removeFuel}
 
-Removes this fuel item with the given burn time from the Altar.
+Removes this fuel item from the Altar.
 
 ```zenscript
-// AltarFuelManager.removeFuel(item as IItemStack, burnTime as int)
-mods.aether.AltarFuelManager.removeFuel(<item:minecraft:coal>, 250);
+// AltarFuelManager.removeFuel(ingredient as IIngredient)
+mods.aether.AltarFuelManager.removeFuel(<item:minecraft:coal>);
+mods.aether.AltarFuelManager.removeFuel(<tag:items:minecraft:planks>);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=removeFuelTag}
-
-Removes the fuel items in this tag with the given burn time from the Altar.
-
-```zenscript
-// AltarFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-mods.aether.AltarFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 
 
 :::

--- a/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
@@ -15,7 +15,7 @@ Adds this item as fuel for the Altar with the given burn time.
 
 ```zenscript
 // AltarFuelManager.addFuel(item as IItemStack, burnTime as int)
-altar.addFuel(<item:minecraft:coal>, 250);
+mods.aether.AltarFuelManager.addFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -32,7 +32,7 @@ Adds the items from this tag as fuel for the Altar with the given burn time.
 
 ```zenscript
 // AltarFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-altar.addFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.AltarFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -49,7 +49,7 @@ Removes this fuel item with the given burn time from the Altar.
 
 ```zenscript
 // AltarFuelManager.removeFuel(item as IItemStack, burnTime as int)
-altar.removeFuel(<item:minecraft:coal>, 250);
+mods.aether.AltarFuelManager.removeFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -66,7 +66,7 @@ Removes the fuel items in this tag with the given burn time from the Altar.
 
 ```zenscript
 // AltarFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-altar.removeFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.AltarFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |

--- a/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/AltarFuelManager.md
@@ -1,0 +1,79 @@
+# AltarFuelManager
+
+## Importing the class
+
+It might be required for you to import the package if you encounter any issues (like casting an Array), so better be safe than sorry and add the import at the very top of the file.
+```zenscript
+import mods.aether.AltarFuelManager;
+```
+
+## Methods
+
+:::group{name=addFuel}
+
+Adds this item as fuel for the Altar with the given burn time.
+
+```zenscript
+// AltarFuelManager.addFuel(item as IItemStack, burnTime as int)
+altar.addFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=addFuelTag}
+
+Adds the items from this tag as fuel for the Altar with the given burn time.
+
+```zenscript
+// AltarFuelManager.addFuelTag(tag as MCTag, burnTime as int)
+altar.addFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuel}
+
+Removes this fuel item with the given burn time from the Altar.
+
+```zenscript
+// AltarFuelManager.removeFuel(item as IItemStack, burnTime as int)
+altar.removeFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuelTag}
+
+Removes the fuel items in this tag with the given burn time from the Altar.
+
+```zenscript
+// AltarFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
+altar.removeFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+

--- a/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.json
@@ -1,0 +1,5 @@
+{
+  "path": "mods/aether/FreezerFuelManager.md",
+  "zenCodeName": "mods.aether.FreezerFuelManager",
+  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+}

--- a/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.json
@@ -1,5 +1,5 @@
 {
   "path": "mods/aether/FreezerFuelManager.md",
   "zenCodeName": "mods.aether.FreezerFuelManager",
-  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+  "searchTerms": [ "addFuel", "removeFuel" ]
 }

--- a/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
@@ -14,65 +14,29 @@ import mods.aether.FreezerFuelManager;
 Adds this item as fuel for the Freezer with the given burn time.
 
 ```zenscript
-// FreezerFuelManager.addFuel(item as IItemStack, burnTime as int)
+// FreezerFuelManager.addFuel(ingredient as IIngredient, burnTime as int)
 mods.aether.FreezerFuelManager.addFuel(<item:minecraft:coal>, 250);
+mods.aether.FreezerFuelManager.addFuel(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 | burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=addFuelTag}
-
-Adds the items from this tag as fuel for the Freezer with the given burn time.
-
-```zenscript
-// FreezerFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-mods.aether.FreezerFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
 
 :::group{name=removeFuel}
 
-Removes this fuel item with the given burn time from the Freezer.
+Removes this fuel item from the Freezer.
 
 ```zenscript
-// FreezerFuelManager.removeFuel(item as IItemStack, burnTime as int)
-mods.aether.FreezerFuelManager.removeFuel(<item:minecraft:coal>, 250);
+// FreezerFuelManager.removeFuel(ingredient as IIngredient)
+mods.aether.FreezerFuelManager.removeFuel(<item:minecraft:coal>);
+mods.aether.FreezerFuelManager.removeFuel(<tag:items:minecraft:planks>);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=removeFuelTag}
-
-Removes the fuel items in this tag with the given burn time from the Freezer.
-
-```zenscript
-// FreezerFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-mods.aether.FreezerFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 
 
 :::

--- a/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
@@ -1,0 +1,78 @@
+# FreezerFuelManager
+
+## Importing the class
+
+It might be required for you to import the package if you encounter any issues (like casting an Array), so better be safe than sorry and add the import at the very top of the file.
+```zenscript
+import mods.aether.FreezerFuelManager;
+```
+
+## Methods
+
+:::group{name=addFuel}
+
+Adds this item as fuel for the Freezer with the given burn time.
+
+```zenscript
+// FreezerFuelManager.addFuel(item as IItemStack, burnTime as int)
+freezer.addFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=addFuelTag}
+
+Adds the items from this tag as fuel for the Freezer with the given burn time.
+
+```zenscript
+// FreezerFuelManager.addFuelTag(tag as MCTag, burnTime as int)
+freezer.addFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuel}
+
+Removes this fuel item with the given burn time from the Freezer.
+
+```zenscript
+// FreezerFuelManager.removeFuel(item as IItemStack, burnTime as int)
+freezer.removeFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuelTag}
+
+Removes the fuel items in this tag with the given burn time from the Freezer.
+
+```zenscript
+// FreezerFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
+freezer.removeFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::

--- a/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/FreezerFuelManager.md
@@ -15,7 +15,7 @@ Adds this item as fuel for the Freezer with the given burn time.
 
 ```zenscript
 // FreezerFuelManager.addFuel(item as IItemStack, burnTime as int)
-freezer.addFuel(<item:minecraft:coal>, 250);
+mods.aether.FreezerFuelManager.addFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -32,7 +32,7 @@ Adds the items from this tag as fuel for the Freezer with the given burn time.
 
 ```zenscript
 // FreezerFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-freezer.addFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.FreezerFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -49,7 +49,7 @@ Removes this fuel item with the given burn time from the Freezer.
 
 ```zenscript
 // FreezerFuelManager.removeFuel(item as IItemStack, burnTime as int)
-freezer.removeFuel(<item:minecraft:coal>, 250);
+mods.aether.FreezerFuelManager.removeFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -66,7 +66,7 @@ Removes the fuel items in this tag with the given burn time from the Freezer.
 
 ```zenscript
 // FreezerFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-freezer.removeFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.FreezerFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |

--- a/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.json
@@ -1,5 +1,5 @@
 {
   "path": "mods/aether/IncubatorFuelManager.md",
   "zenCodeName": "mods.aether.IncubatorFuelManager",
-  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+  "searchTerms": [ "addFuel", "removeFuel" ]
 }

--- a/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.json
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.json
@@ -1,0 +1,5 @@
+{
+  "path": "mods/aether/IncubatorFuelManager.md",
+  "zenCodeName": "mods.aether.IncubatorFuelManager",
+  "searchTerms": [ "addFuel", "addFuelTag", "removeFuel", "removeFuelTag" ]
+}

--- a/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
@@ -1,0 +1,78 @@
+# IncubatorFuelManager
+
+## Importing the class
+
+It might be required for you to import the package if you encounter any issues (like casting an Array), so better be safe than sorry and add the import at the very top of the file.
+```zenscript
+import mods.aether.IncubatorFuelManager;
+```
+
+## Methods
+
+:::group{name=addFuel}
+
+Adds this item as fuel for the Incubator with the given burn time.
+
+```zenscript
+// IncubatorFuelManager.addFuel(item as IItemStack, burnTime as int)
+incubator.addFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=addFuelTag}
+
+Adds the items from this tag as fuel for the Incubator with the given burn time.
+
+```zenscript
+// IncubatorFuelManager.addFuelTag(tag as MCTag, burnTime as int)
+incubator.addFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuel}
+
+Removes this fuel item with the given burn time from the Incubator.
+
+```zenscript
+// IncubatorFuelManager.removeFuel(item as IItemStack, burnTime as int)
+incubator.removeFuel(<item:minecraft:coal>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::
+
+:::group{name=removeFuelTag}
+
+Removes the fuel items in this tag with the given burn time from the Incubator.
+
+```zenscript
+// IncubatorFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
+incubator.removeFuelTag(<tag:items:minecraft:planks>, 250);
+```
+
+| Parameter | Type | Description | Optional |
+|-----------|------|-------------|----------|
+| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
+| burnTime | int | the fuel's burn time | false |
+
+
+:::

--- a/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
@@ -15,7 +15,7 @@ Adds this item as fuel for the Incubator with the given burn time.
 
 ```zenscript
 // IncubatorFuelManager.addFuel(item as IItemStack, burnTime as int)
-incubator.addFuel(<item:minecraft:coal>, 250);
+mods.aether.IncubatorFuelManager.addFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -32,7 +32,7 @@ Adds the items from this tag as fuel for the Incubator with the given burn time.
 
 ```zenscript
 // IncubatorFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-incubator.addFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.IncubatorFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -49,7 +49,7 @@ Removes this fuel item with the given burn time from the Incubator.
 
 ```zenscript
 // IncubatorFuelManager.removeFuel(item as IItemStack, burnTime as int)
-incubator.removeFuel(<item:minecraft:coal>, 250);
+mods.aether.IncubatorFuelManager.removeFuel(<item:minecraft:coal>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
@@ -66,7 +66,7 @@ Removes the fuel items in this tag with the given burn time from the Incubator.
 
 ```zenscript
 // IncubatorFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-incubator.removeFuelTag(<tag:items:minecraft:planks>, 250);
+mods.aether.IncubatorFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |

--- a/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
+++ b/docs_exported/1.19.4/aether/docs/mods/aether/IncubatorFuelManager.md
@@ -14,65 +14,29 @@ import mods.aether.IncubatorFuelManager;
 Adds this item as fuel for the Incubator with the given burn time.
 
 ```zenscript
-// IncubatorFuelManager.addFuel(item as IItemStack, burnTime as int)
+// IncubatorFuelManager.addFuel(ingredient as IIngredient, burnTime as int)
 mods.aether.IncubatorFuelManager.addFuel(<item:minecraft:coal>, 250);
+mods.aether.IncubatorFuelManager.addFuel(<tag:items:minecraft:planks>, 250);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 | burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=addFuelTag}
-
-Adds the items from this tag as fuel for the Incubator with the given burn time.
-
-```zenscript
-// IncubatorFuelManager.addFuelTag(tag as MCTag, burnTime as int)
-mods.aether.IncubatorFuelManager.addFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
 
 :::group{name=removeFuel}
 
-Removes this fuel item with the given burn time from the Incubator.
+Removes this fuel item from the Incubator.
 
 ```zenscript
-// IncubatorFuelManager.removeFuel(item as IItemStack, burnTime as int)
-mods.aether.IncubatorFuelManager.removeFuel(<item:minecraft:coal>, 250);
+// IncubatorFuelManager.removeFuel(ingredient as IIngredient)
+mods.aether.IncubatorFuelManager.removeFuel(<item:minecraft:coal>);
+mods.aether.IncubatorFuelManager.removeFuel(<tag:items:minecraft:planks>);
 ```
 
 | Parameter | Type | Description | Optional |
 |-----------|------|-------------|----------|
-| item | [IItemStack](/vanilla/api/item/IItemStack) | fuel [IItemStack](/vanilla/api/item/IItemStack) | false |
-| burnTime | int | the fuel's burn time | false |
-
-
-:::
-
-:::group{name=removeFuelTag}
-
-Removes the fuel items in this tag with the given burn time from the Incubator.
-
-```zenscript
-// IncubatorFuelManager.removeFuelTag(tag as MCTag, burnTime as int)
-mods.aether.IncubatorFuelManager.removeFuelTag(<tag:items:minecraft:planks>, 250);
-```
-
-| Parameter | Type | Description | Optional |
-|-----------|------|-------------|----------|
-| item | [MCTag](/vanilla/api/tag/MCTag) | fuel [MCTag](/vanilla/api/tag/MCTag) | false |
-| burnTime | int | the fuel's burn time | false |
+| item | [IIngredient](/vanilla/api/ingredient/IIngredient) | fuel [IIngredient](/vanilla/api/ingredient/IIngredient) | false |
 
 
 :::


### PR DESCRIPTION
Adds documentation for The Aether's CraftTweaker compatibility. This includes methods for manipulating the fuel items for the Altar, Freezer, and Incubator.