### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/docs/1.16/content/mods/zensummoning/examples.md
+++ b/docs/1.16/content/mods/zensummoning/examples.md
@@ -19,7 +19,7 @@ Looking at the recipes for spawn eggs will show summonings that include the mob 
     - If it's successful, displays "Woohoo!"
 - Gives the mobs custom NBT
     - 1.16 renamed generic.maxHealth to generic.max_health.
-    - [https://minecraft.fandom.com/wiki/Attribute](https://minecraft.fandom.com/wiki/Attribute)
+    - [https://minecraft.wiki/w/Attribute](https://minecraft.wiki/w/Attribute)
 
 ```zenscript
 import crafttweaker.api.item.IItemStack;


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>.

There are also 2 old URLs in [docs_exported](https://github.com/CraftTweaker/CraftTweaker-Documentation/blob/main/docs_exported/1.16/crafttweaker/docs/vanilla/api/entity/MCEntity.md) but since those seem to be generated and I couldn't immediately find its source I just left it.