### PR TITLE
(Typo Fix) Request to update Conditional_Statements.md in order to improve consistency.

### DIFF
--- a/docs/1.12/content/AdvancedFunctions/Conditional_Statements.md
+++ b/docs/1.12/content/AdvancedFunctions/Conditional_Statements.md
@@ -116,7 +116,7 @@ All the examples given evaluate to true.
 | Not               | `!`          | Inverts a boolean                                                                         | !false             |
 | Not Equal         | `!=`         | Checks if the value before and after are not equal                                        | 1 != 2             |
 | Equal             | `==`         | Checks if the value before and after are equal                                            | 1 == 1             |
-| Greater than      | `>`          | Checks if the value before is greater than after                                          | 1 > 2              |
+| Greater than      | `>`          | Checks if the value before is greater than after                                          | 1 > 0              |
 | Greater or Equal  | `>=`         | Checks if the value before is greater than or equal with after                            | 1 >= 1             |
 | Lesser than       | `<`          | Checks if the value before is fewer than after                                            | 1 < 2              |
 | Lesser or Equal   | `<=`         | Checks if the value before is fewer than or equal with after                              | 1 <= 1             |


### PR DESCRIPTION
Fixed an incorrect example that was inconsistent with the previous statement of "All the examples given evaluate to true."
Previously, it had stated 1 > 2, which evaluated to false - inconsistent with the rest of the examples given. Replaced the 2 with a 0, making it 1 > 0.

Sorry for my verbosity :sweat_smile: 