### PR TITLE
Add MoreTweaker wiki

### DIFF
--- a/docs/1.12/content/Mods/MoreTweaker/BloodArsenal.md
+++ b/docs/1.12/content/Mods/MoreTweaker/BloodArsenal.md
@@ -1,0 +1,44 @@
+# Blood Arsenal
+
+### Infusion de Sanguine
+
+```
+import moretweaker.bloodarsenal.Sanguine;
+
+Sanguine.addRecipe(IItemStack output, int lpCost, IItemStack catalyst, IIngredient[] inputs);
+
+Sanguine.removeRecipe(IIngredient output);
+
+Sanguine.addModifier(String modifier, int lpCost, IIngredient[] inputs);
+
+Sanguine.removeModifier(String modifier);
+
+Sanguine.removeAll();
+```
+
+By adding or removing modifiers, the amount of the inputs will
+get multiplied with the level that gets applied.
+
+##### Fields
+
+The values for the `modifier` parameter are stored in fields
+of the `Sanguine` class:
+
+```
+import moretweaker.bloodarsenal.Sanguine;
+
+Sanguine.BAD_POTION;
+Sanguine.BLOOD_LUST;
+Sanguine.FLAME; 
+Sanguine.SHARPNESS; 
+Sanguine.FORTUNATE; 
+Sanguine.LOOTING; 
+Sanguine.SILKY; 
+Sanguine.SMELTING; 
+Sanguine.EXPERIENCED; 
+Sanguine.BENEFICIAL_POTION; 
+Sanguine.QUICK_DRAW; 
+Sanguine.SHADOW_TOOL; 
+Sanguine.AOD; 
+Sanguine.SIGIL; 
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Buildcraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Buildcraft.md
@@ -1,0 +1,43 @@
+# Buildcraft
+
+**Known Bug**: Buildcraft support is borked. removeAll() doesnt work, removeDistilling() doesnt work, and the game crashes if you try to add a fluid thats already added, even if you have said to remove it using either of the previous two methods. Buildcraft Heat Exchanger recipes
+
+All energy-costs are in MJ
+
+### Assembly Table
+
+```
+import moretweaker.buildcraft.AssemblyTable;
+
+AssemblyTable.add(IItemStack output, long energyCost, IIngredient[] inputs);
+
+AssemblyTable.remove(IIngredient output);
+
+AssemblyTable.removeAll();
+```
+
+### Integration Table
+
+The catalyst is the stack in the middle. Recipes are removed by catalyst, **not** by output.
+
+```
+import moretweaker.buildcraft.IntegrationTable;
+
+IntegrationTable.add(IItemStack output, long energyCost, IIngredient catalyst, IIngredient[] inputs);
+
+IntegrationTable.remove(IIngredient catalyst);
+
+IntegrationTable.removeAll();
+```
+
+### Refinery
+
+```
+import moretweaker.buildcraft.Refinery;
+
+Refinery.addDistilling(ILiquidStack input, ILiquidStack output, ILiquidStack gasOutput, int energy);
+
+Refinery.removeDistilling(ILiquidStack input);
+
+Refinery.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/DraconicEvolution.md
+++ b/docs/1.12/content/Mods/MoreTweaker/DraconicEvolution.md
@@ -1,0 +1,38 @@
+# Draconic Evolution
+
+### Fusion Crafting
+
+The catalyst is the stack in the center before the recipe starts.
+
+
+```
+import moretweaker.draconicevolution.FusionCrafting;
+
+FusionCrafting.add(IItemStack output, IItemStack catalyst, int tier, long energyCost, IIngredient[] ingredients);
+
+FusionCrafting.remove(IIngredient catalyst);
+
+FusionCrafting.removeAll();
+```
+
+##### Fields
+
+The `int` values for the parameter `tier` are stored in
+fields of the `FusionCrafting` class:
+
+```
+import moretweaker.draconicevolution.FusionCrafting;
+
+FusionCrafting.BASIC;
+FusionCrafting.WYVERN;
+FusionCrafting.DRACONIC;
+FusionCrafting.CHAOTIC;
+```
+
+##### Example
+
+```
+import moretweaker.draconicevolution.FusionCrafting;
+
+FusionCrafting.add(<minecraft:diamond>, <minecraft:coal>, FusionCrafting.WYVERN, 100000, [<minecraft:stone>, <minecraft:stone>]]);
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Enderfuge.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Enderfuge.md
@@ -1,0 +1,19 @@
+# Enderfuge
+
+### Endefuge
+
+```
+import moretweaker.enderfuge.EnderFuge;
+
+EnderFuge.addRecipe(IItemStack output, IIngredient input);
+
+EnderFuge.removeRecipe(IIngredient output);
+
+EnderFuge.addFuel(IIngredient fuel, optional int burnTicks);
+
+EnderFuge.removeFuel(IIngredient fuel);
+
+EnderFuge.removeAllRecipes();
+
+EnderFuge.removeAllFuels();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Erebus.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Erebus.md
@@ -1,0 +1,45 @@
+# Erebus
+
+Due to the way that Erebus handles it's recipes only `IItemStack`
+and `IOreDictEntry` are allowed item ingredients.
+
+### Composter
+
+```
+import moretweaker.erebus.Composter;
+
+Composter.add(IItemStack compostable);
+
+Composter.addAll(IItemStack[] compostables);
+
+Composter.remove(IItemStack nonCompostable);
+
+Composter.removeAll(IItemStack[] nonCompostables);
+```
+
+### Offering Altar
+
+```
+import moretweaker.erebus.OfferingAltar;
+
+OfferingAltar.addRecipe(IItemStack output, IIngredient input1, IIngredient input2, IIngredient input3);
+
+OfferingAltar.removeRecipe(IIngredient output);
+
+OfferingAltar.removeAll();
+```
+
+### Smoothie Maker
+
+The parameter named `container` has to be in the output slot
+for the recipe to start.
+
+```
+import moretweaker.erebus.SmoothieMaker;
+
+SmoothieMaker.addRecipe(IItemStack output, optional IItemStack container, IIngredient[] inputs, ILiquidStack[] fluids);
+
+SmoothieMaker.removeRecipe(IIngredient output);
+
+SmoothieMaker.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Gadgetry.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Gadgetry.md
@@ -1,0 +1,49 @@
+# Gadgetry
+
+### Alloy Furnace
+
+```
+import moretweaker.gadgetry.AlloyFurnace;
+
+AlloyFurnace.add(IItemStack output, IIngredient[] inputs);
+
+AlloyFurnace.remove(IIngredient output);
+
+AlloyFurnace.removeAll();
+```
+
+### Combustion Generator
+
+```
+import moretweaker.gadgetry.CombustionGenerator;
+
+CombustionGenerator.add(ILiquidStack liquid, int energyPerMb);
+
+CombustionGenerator.remove(ILiquidStack liquid);
+
+CombustionGenerator.removeAll();
+```
+
+### Distillery
+
+```
+import moretweaker.gadgetry.Distillery;
+
+Distillery.add(IItemStack output, ILiquidStack fluidOutput, IIngredient input, ILiquidStack fluidInput);
+
+Distillery.remove(IIngredient output);
+
+Distillery.removeAll();
+```
+
+### Grinder
+
+```
+import moretweaker.gadgetry.Grinder;
+
+Grinder.add(IItemStack output, IIngredient input);
+
+Grinder.remove(IIngredient output);
+
+Grinder.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Galacticraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Galacticraft.md
@@ -1,0 +1,23 @@
+# Galacticraft
+
+### Circuit Fabricator
+
+```
+import moretweaker.galacticraft.CircuitFabricator;
+
+CircuitFabricator.add(IItemStack output, IIngredient[] inputs);
+
+CircuitFabricator.remove(IItemStack output);
+```
+
+### Compressor
+
+```
+import moretweaker.galacticraft.Compressor;
+
+Compressor.addShaped(IItemStack output, IItemStack[][] inputs);
+
+Compressor.addShapeless(IItemStack output, IIngredient[] inputs);
+
+Compressor.remove(IItemStack output);
+```

--- a/docs/1.12/content/Mods/MoreTweaker/InfinityCraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/InfinityCraft.md
@@ -1,0 +1,13 @@
+# InfinityCraft
+
+### Compressor
+
+```
+import moretweaker.infinitycraft.Compressor;
+
+Compressor.addRecipe(IIngredient input, IItemStack output, optional int experience);
+
+Compressor.removeRecipe(IIngredient output);
+
+Compressor.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Known bugs.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Known bugs.md
@@ -1,0 +1,7 @@
+## Known bugs
+- Buildcraft support is borked. removeAll() doesnt work, removeDistilling() doesnt work, and the game crashes if you try to add a fluid thats already added, even if you have said to remove it using either of the previous two methods. Buildcraft Heat Exchanger recipes
+- new recipes for the Spinning Wheel from Bewitchment
+- running power of the witches ritual
+- AoA support is borked
+- Voidcraft doesn't exist anymore?
+- Recipes are not deleted from the Thut's Elevators

--- a/docs/1.12/content/Mods/MoreTweaker/LightningCraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/LightningCraft.md
@@ -1,0 +1,33 @@
+# LightningCraft
+
+### Lightning Transforming
+
+```
+import moretweaker.lightningcraft.LightningTransforming;
+
+LightningTransforming.add(IItemStack output, IItemStack[] inputs);
+```
+
+### Lightning Crusher
+
+```
+import moretweaker.lightningcraft.LightningCrusher;
+
+LightningCrusher.add(IItemStack output, IIngredient input);
+
+LightningCrusher.remove(IIngredient output);
+
+LightningCrusher.removeAll();
+```
+
+### Lightning Infusion
+
+```
+import moretweaker.lightningcraft.LightningInfusion;
+
+LightningInfusion.add(IItemStack output, IIngredient catalyst, int requiredLE, IIngredient[] inputs);
+
+LightningInfusion.remove(IIngredient output);
+
+LightningInfusion.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/MGU.md
+++ b/docs/1.12/content/Mods/MoreTweaker/MGU.md
@@ -1,0 +1,19 @@
+# Mob Grinding Utils
+
+### Chicken-Feed
+
+You may change the Spawn-Egg dropped by the chicken-feed.
+
+```
+import moretweaker.mob_grinding_utils.ChickenFeed;
+
+ChickenFeed.setSpawnEgg(String mobId, IItemStack spawnegg);
+
+ChickenFeed.resetSpawnEgg(String mobId);
+```
+
+Example:
+
+```
+ChickenFeed.setSpawnEgg("minecraft:enderman", <minecraft:ender_pearl>);
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Matteroverdrive.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Matteroverdrive.md
@@ -1,0 +1,23 @@
+# Matter Overdrive
+
+### Inscriber
+
+The `energy` value is *FE* and the `time` value is *ticks* (1/20 of a second).
+
+```
+import moretweaker.matteroverdrive.Inscriber;
+
+Inscriber.addRecipe(IIngredient input1, IIngredient input2, IItemStack output, int energy, int time);
+
+Inscriber.removeRecipe(IIngredient output);
+
+Inscriber.removeAll();
+```
+
+### Matter
+
+```
+import moretweaker.matteroverdrive.Matter;
+
+Matter.set(IIngredient input, int matter);
+```

--- a/docs/1.12/content/Mods/MoreTweaker/Railcraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/Railcraft.md
@@ -1,0 +1,63 @@
+# Railcraft
+
+### Blast Furnace
+
+```
+import moretweaker.railcraft.BlastFurnace;
+
+BlastFurnace.add(IItemStack output, IIngredient input, optional int ticks, optional int slag);
+
+BlastFurnace.remove(IIngredient output);
+
+BlastFurnace.removeAll();
+```
+
+### Coke Oven
+
+```
+import moretweaker.railcraft.CokeOven;
+
+CokeOven.add(IItemStack output, IIngredient input, ILiquidStack liquidOutput, optional int ticks);
+
+CokeOven.remove(IIngredient output);
+
+CokeOven.removeAll();
+```
+
+### Rock Crusher
+
+```
+import moretweaker.railcraft.RockCrusher;
+
+RockCrusher.add(IIngredient input, IItemStack[] outputs, float[] chances, optional int ticks);
+
+RockCrusher.remove(IIngredient output);
+
+RockCrusher.removeAll();
+```
+
+### Rolling Machine
+
+```
+import moretweaker.railcraft.RollingMachine;
+
+RollingMachine.addShaped(IItemStack output, IIngredient[][] inputs, optional int ticks);
+
+RollingMachine.addShapeless(IItemStack output, IIngredient[] inputs, optional int ticks);
+
+RollingMachine.remove(IIngredient output);
+
+RollingMachine.removeAll();
+```
+
+### Fluid Fuels
+
+```
+import moretweaker.railcraft.FluidFuels;
+
+FluidFuels.add(ILiquidStack fuel, optional int heatPerBucket);
+
+FluidFuels.remove(ILiquidStack fuel);
+
+FluidFuels.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/VoidCraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/VoidCraft.md
@@ -1,0 +1,55 @@
+# VoidCraft
+
+Author note: This mod doesn't seem to exist anymore, but MoreTweaker didn't delete their integration for it
+
+### Voidic Macerator
+
+```
+import moretweaker.voidcraft.VoidMacerator;
+
+VoidMacerator.add(IItemStack output, IIngredient input, optional int voidicPower);
+
+VoidMacerator.remove(IIngredient output);
+
+VoidMacerator.removeAll();
+```
+
+### Voidic Blast-Furnace
+
+The Voidic Blast-Furnace may have custom recipes added but you will not be able to put any items different from iron dust and coal dust into its slots.
+
+```
+import moretweaker.voidcraft.VoidFurnace;
+
+VoidFurnace.add(IItemStack output, IIngredient input1, IIngredient input2, optional int voidicPower);
+
+VoidFurnace.remove(IIngredient output);
+
+VoidFurnace.removeAll();
+```
+
+### Voidic Alchemy-Table
+
+The array in the `add` method must have a length of 6.
+
+```
+import moretweaker.voidcraft.VoidAlchemy;
+
+VoidAlchemy.add(IItemStack output, IIngredient[] inputs, optional int voidicPower);
+
+VoidAlchemy.remove(IIngredient output);
+
+VoidAlchemy.removeAll();
+```
+
+### Void-Infuser
+
+```
+import moretweaker.voidcraft.VoidInfusion;
+
+VoidInfusion.add(IItemStack output, IIngredient input, int voidicFluid);
+
+VoidInfusion.remove(IIngredient output);
+
+VoidInfusion.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/aoa.md
+++ b/docs/1.12/content/Mods/MoreTweaker/aoa.md
@@ -1,0 +1,31 @@
+# Advent of Ascension
+
+**THIS HAS NOT BEEN TESTED. BEFORE USING READ [THIS](https://legacy.curseforge.com/minecraft/mc-mods/moretweaker?comment=33)**
+
+### InfusionTable
+
+```
+import moretweaker.aoa.InfusionTable;
+
+InfusionTable.addRecipe(IItemStack output, IItemStack mainInput, IIngredient[] inputs, optional int infusionLevel, optional int xpMin, optional int xpMax);
+
+InfusionTable.addRecipe(String enchantmentId, int enchantmentLevel, IIngredient[] inputs, optional int infusionLevel, optional int xpMin, optional int xpMax);
+
+InfusionTable.removeRecipe(IIngredient output);
+
+InfusionTable.removeRecipe(String enchantmentId);
+
+InfusionTable.removeAll();
+```
+
+### Divine Station (Upgrade Kits)
+
+```
+import moretweaker.aoa.DivineStation;
+
+DivineStation.addRecipe(IItemStack input, IItemStack upgradeKit, IItemStack output);
+
+DivineStation.removeRecipe(IIngredient output);
+
+DivineStation.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/bedrockcraft.md
+++ b/docs/1.12/content/Mods/MoreTweaker/bedrockcraft.md
@@ -1,0 +1,29 @@
+# BedrockCraft
+
+### Dust Infusion
+
+```
+import moretweaker.bedrockcraft.DustInfusion;
+
+DustInfusion.addRecipe(IItemStack block, IItemStack output);
+
+DustInfusion.removeRecipe(IItemStack block);
+```
+
+`block` is the target block one needs to click. Recipes are
+removed by that block, not by output.
+
+### Bedrock Ritual
+
+```
+import moretweaker.bedrockcraft.BedrockRitual;
+
+BedrockRitual.addRecipe(IItemStack output, IIngredient center, int bedrockAmount, IIngredient[] inputs);
+
+BedrockRitual.removeRecipe(IIngredient output);
+
+BedrockRitual.removeAll();
+```
+
+When adding recipes the `inputs` array must have a length of
+2, 3, 4, 6, or 12.

--- a/docs/1.12/content/Mods/MoreTweaker/betweenlands.md
+++ b/docs/1.12/content/Mods/MoreTweaker/betweenlands.md
@@ -1,0 +1,67 @@
+# The Betweenlands
+
+### Animator
+
+```
+import moretweaker.betweenlands.Animator;
+
+Animator.addRecipe(IItemStack input, int fuel, int life, IItemStack output);
+
+Animator.addRecipe(IItemStack input, int fuel, int life, String entity);
+
+Animator.removeRecipe(IIngredient output);
+
+Animator.removeRecipe(String entityOutput);
+
+Animator.removeAll();
+```
+
+Entity can for example be `minecraft:wither`.
+
+### Compost Bin
+
+```
+import moretweaker.betweenlands.Composter;
+
+Composter.addRecipe(IIngredient input);
+
+Composter.addRecipe(IIngredient input, int compostValue, int compostTime);
+```
+
+### Druid Altar
+
+The inputs array must have a length of 4.
+
+```
+import moretweaker.betweenlands.DruidAltar;
+
+DruidAltar.addRecipe(IItemStack output, IIngredient[] inputs);
+
+DruidAltar.removeRecipe(IIngredient output);
+
+DruidAltar.removeAll();
+```
+
+### Pestle & Mortar
+
+```
+import moretweaker.betweenlands.Mortar;
+
+Mortar.addRecipe(IIngredient input, IItemStack output);
+
+Mortar.removeRecipe(IIngredient output);
+
+Mortar.removeAll();
+```
+
+### Purifier
+
+```
+import moretweaker.betweenlands.Purifier;
+
+Purifier.addRecipe(IIngredient input, IItemStack output);
+
+Purifier.removeRecipe(IIngredient output);
+
+Purifier.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/bewitchment.md
+++ b/docs/1.12/content/Mods/MoreTweaker/bewitchment.md
@@ -1,0 +1,90 @@
+# Bewitchment
+
+**Known Bug**: new recipes for the Spinning Wheel from Bewitchment
+
+### Distillery
+
+```
+import moretweaker.bewitchment.Distillery;
+
+Distillery.addRecipe(IItemStack[] outputs, IIngredient[] inputs);
+
+Distillery.removeRecipe(IIngredient output);
+
+Distillery.removeAll();
+```
+
+### FrostFire
+
+```
+import moretweaker.bewitchment.FrostFire;
+
+FrostFire.addRecipe(IItemStack output, IIngredient input);
+
+FrostFire.removeRecipe(IIngredient output);
+
+FrostFire.removeAll();
+```
+
+### Witches Cauldron
+
+```
+import moretweaker.bewitchment.WitchesCauldron;
+
+WitchesCauldron.addRecipe(IItemStack[] outputs, IIngredient[] inputs);
+
+WitchesCauldron.removeRecipe(IIngredient output);
+
+WitchesCauldron.removeAllRecipes();
+
+WitchesCauldron.addBrew(IIngredient[] trigger, String potion, optional int duration, optional int amplifier);
+
+WitchesCauldron.removeBrew(IIngredient trigger);
+
+WitchesCauldron.removeAllBrews();
+```
+
+### Witches Oven
+
+```
+import moretweaker.bewitchment.WitchesOven;
+
+WitchesOven.addRecipe(IIngredient input, IItemStack output, IItemStack byproduct, optional float chance, optional boolean requiresJar);
+
+WitchesOven.removeRecipe(IIngredient output);
+
+WitchesOven.removeAll();
+```
+
+### Witches Ritual
+
+```
+import moretweaker.bewitchment.WitchesRitual;
+
+WitchesRitual.addRecipe(String name, IItemStack[] outputs, IIngredient[] inputs, String entityOutput, String entityInput, int power, int ringSmall, int ringMedium, int ringLarge)
+
+WitchesRitual.removeByOutput(IIngredient output);
+
+WitchesRitual.removeByInput(IIngredient input);
+
+WitchesRitual.removeAll();
+```
+
+The values for the parameters `ringSmall`, `ringMedium` and `ringLarge` are stored in the following Fields of `moretweaker.bewitchment.WitchesRitual`:
+```
+import moretweaker.bewitchment.WitchesRitual;
+
+WitchesRitual.NONE;      // No chalk
+
+WitchesRitual.GOLDEN;    // Golden chalk
+
+WitchesRitual.RITUAL;    // Ritual Chalk (The standard white chalk)
+
+WitchesRitual.FIERY;     // Fiery/Infernal chalk
+
+WitchesRitual.PHASING;   // Phasing/Otherwhere chalk
+
+WitchesRitual.ANY;       // No matter what chalk
+```
+
+The field `GOLDEN` always throws an exception when used because you can't have golden rings.

--- a/docs/1.12/content/Mods/MoreTweaker/cfb.md
+++ b/docs/1.12/content/Mods/MoreTweaker/cfb.md
@@ -1,0 +1,31 @@
+# Cooking for Blockheads
+
+```
+import moretweaker.cfb.KitchenAppliances;
+
+KitchenAppliances.addToasterRecipe(IItemStack output, IIngredient input);
+
+KitchenAppliances.removeToasterRecipe(IIngredient output);
+
+KitchenAppliances.removeAllToasterRecipes();
+
+KitchenAppliances.addSinkRecipe(IItemStack output, IIngredient input);
+
+KitchenAppliances.removeSinkRecipe(IIngredient output);
+
+KitchenAppliances.removeAllSinkRecipes();
+
+KitchenAppliances.addOvenRecipe(IItemStack output, IIngredient input);
+
+KitchenAppliances.removeOvenRecipe(IIngredient output);
+
+KitchenAppliances.removeAllOvenRecipes();
+
+KitchenAppliances.addFoodShapeless(IItemStack output, IIngredient[] inputs);
+
+KitchenAppliances.addFoodShaped(IItemStack output, IIngredient[][] inputs);
+
+KitchenAppliances.removeFoodRecipe(IIngredient output);
+
+KitchenAppliances.removeAllFoodRecipes();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/fossil.md
+++ b/docs/1.12/content/Mods/MoreTweaker/fossil.md
@@ -1,0 +1,57 @@
+# Fossils and Archeology
+
+Fossils and Archeology has native CraftTweaker support. But as this is a bit broken and does not allow removing recipes by output in the analyzer and sifter, here's my version:
+
+### Analyzer
+
+```
+import moretweaker.fossil.Analyzer;
+
+Analyzer.addOutput(IIngredient input, IItemStack output, double weight);
+
+Analyzer.removeByInput(IIngredient input);
+
+Analyzer.removeByOutput(IIngredient output);
+
+Analyzer.removeAll();
+```
+
+### Sifter
+
+```
+import moretweaker.fossil.Sifter;
+
+Sifter.addOutput(IIngredient input, IItemStack output, double weight);
+
+Sifter.removeByInput(IIngredient input);
+
+Sifter.removeByOutput(IIngredient output);
+
+Sifter.removeAll();
+```
+
+### Archeology Workbench
+
+```
+import moretweaker.fossil.ArcheologyWorkbench;
+
+ArcheologyWorkbench.addRecipe(IIngredient input, IItemStack output, optional IIngredient fuel);
+
+ArcheologyWorkbench.removeRecipe(IIngredient output);
+
+ArcheologyWorkbench.removeAll();
+```
+
+### Culture Vat
+
+The Culture Vat may have custom recipes added but you will not be able to put any new items in the input slot.
+
+```
+import moretweaker.fossil.CultureVat;
+
+CultureVat.addRecipe(IIngredient input, IItemStack output);
+
+CultureVat.removeRecipe(IIngredient output);
+
+CultureVat.removeAll();
+```

--- a/docs/1.12/content/Mods/MoreTweaker/hwell.md
+++ b/docs/1.12/content/Mods/MoreTweaker/hwell.md
@@ -1,0 +1,39 @@
+# Hearth  Well
+
+There is already crafttweaker support for Hearth Well, but it is lacking some features regarding the coring.
+
+**IMPORTANT: you should not use the native Hearth Well support to modify coring recipes if you're using this, or you might be in trouble.**
+
+### MoreCoring
+
+```
+import moretweaker.hwell.MoreCoring;
+
+MoreCoring.removeCoring(@Nullable String coreId, @Nullable String shardId);
+MoreCoring.addCoring(String coreId, String shardId, IItemStack[] output, IItemStack[] input);
+```
+
+If `coreId` or `shardId` is null, it'll match every core / shard. So to remove al recipes from the heat core you can do:
+
+```
+MoreCoring.removeCoring("core_heat", null);
+```
+
+#### Core Ids
+
+  * Rock Core: `core_stone`
+  * Anima Core: `core_anima`
+  * Warm Core: `core_heat`
+  * Verdant Core: `core_green`
+  * Sentient Core: `core_sentient`
+
+#### Shard Ids
+
+  * Shard of the Soil of Fire: `shard_c`
+  * Shard of the Sacred Land: `shard_fe`
+  * Shard of the Shining Dawn: `shard_au`
+  * Shard of the Root of Life: `shard_o`
+  * Shard of the Living World: `shard_h`
+  * Shard of the Born Might: `shard_ca`
+  * Shard of the Morning Star: `shard_p`
+  * Shard of the Pure Giver: `shard_n`

--- a/docs/1.12/content/Mods/MoreTweaker/jei.md
+++ b/docs/1.12/content/Mods/MoreTweaker/jei.md
@@ -1,0 +1,15 @@
+# JEI
+
+There is already crafttweaker support for JEI, but it is lacking some features regarding the information pages.
+
+**IMPORTANT: you should not use the native JEI support of crafttweaker to modify information pages if you're using this, or you might be in trouble.**
+
+### MoreJei
+
+```
+import moretweaker.jei.MoreJei;
+
+MoreJei.removeDescription(IIngredient input);
+
+MoreJei.addDescription(IIngredient input, String[] description);
+```

--- a/docs/1.12/content/Mods/MoreTweaker/quacklib.md
+++ b/docs/1.12/content/Mods/MoreTweaker/quacklib.md
@@ -1,0 +1,17 @@
+# Quack Lib
+
+### Alloy Furnace
+
+```
+import moretweaker.quacklib.AlloyFurnace;
+
+AlloyFurnace.addRecipe(IItemStack output, IIngredient[] inputs);
+
+AlloyFurnace.removeRecipe(IIngredient output);
+
+AlloyFurnace.removeAll();
+```
+
+When using ingredients that are matching multiple stacks only
+one of them is displayed in JEI. That is not because of
+MoreTweaker. It's because of QuackLib JEI support.

--- a/docs/1.12/docs.json
+++ b/docs/1.12/docs.json
@@ -1040,6 +1040,31 @@
           "RecipePrimer": "Mods/ModularMachinery/Recipes/RecipePrimer.md"
         }
       },
+      "MoreTweaker": {
+        "Known Bugs": "Mods/MoreTweaker/Known bugs.md",
+        "Advent of Ascension (Nevermine)": "Mods/MoreTweaker/aoa.md",
+        "Bedrockcraft": "Mods/MoreTweaker/bedrockcraft.md",
+        "Bewitchment": "Mods/MoreTweaker/bewitchment.md",
+        "Blood Arsenal": "Mods/MoreTweaker/BloodArsenal.md",
+        "Buildcraft": "Mods/MoreTweaker/Buildcraft.md",
+        "Cooking for Blockheads": "Mods/MoreTweaker/cfb.md",
+        "Draconic Evolution": "Mods/MoreTweaker/DraconicEvolution.md",
+        "Enderfuge": "Mods/MoreTweaker/Enderfuge.md",
+        "Erebus": "Mods/MoreTweaker/Erebus.md",
+        "Fossils and Archeology": "Mods/MoreTweaker/fossil.md",
+        "Gadgetry": "Mods/MoreTweaker/Gadgetry.md",
+        "Galacticraft": "Mods/MoreTweaker/Galacticraft.md",
+        "Hearth  Well": "Mods/MoreTweaker/hwell.md",
+        "InfinityCraft": "Mods/MoreTweaker/InfinityCraft.md",
+        "JEI": "Mods/MoreTweaker/jei.md",
+        "LightningCraft": "Mods/MoreTweaker/LightningCraft.md",
+        "Matter Overdrive": "Mods/MoreTweaker/Matteroverdrive.md",
+        "Mob Grinding Utils": "Mods/MoreTweaker/MGU.md",
+        "Quack lib": "Mods/MoreTweaker/quacklib.md",
+        "Railcraft": "Mods/MoreTweaker/Railcraft.md",
+        "The Betweenlands": "Mods/MoreTweaker/betweenlands.md",
+        "VoidCraft": "Mods/MoreTweaker/VoidCraft.md"
+      },
       "MrCrayfish's Furniture Mod": {
         "MrCrayfish's Furniture Mod": "Mods/MrCrayfish_s_Furniture_Mod/MrCrayfish_s_Furniture_Mod.md",
         "Crafting": {


### PR DESCRIPTION
[MoreTweaker](https://www.curseforge.com/minecraft/mc-mods/moretweaker) is a CraftTweaker addon that currently has [off-platform docs on BitBucket](https://bitbucket.org/noeppi_noeppi/moretweaker/wiki/Home).

However, BitBucket will be removing these docs on August 20, 2026.

I have downloaded them and made this PR so they are still accessible. Most text is verbatim what was on the wiki, with the addition of **Known Bug**: entries that were copied from the Known Bugs page

This is my first PR to the docs, and I have not built the project locally nor tested anything, please inform me of any mistakes